### PR TITLE
Update to new vchan-xen package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - PACKAGE=mirage-qubes EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+  - PINS="vchan:git://github.com/mirage/ocaml-vchan vchan-xen:git://github.com/mirage/ocaml-vchan"
   matrix:
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.03 DEPOPTS="ipaddr tcpip"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### 0.4 (unreleased)
+### 0.4 (2017-01-20)
 
 - Include an ipv4 sublibrary for automatically configuring ipv4 settings from qubesdb.
 

--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 true: annot, bin_annot, safe_string
 true: warn(A-4), strict_sequence
 <lib> : include
-<lib/*>: package(cstruct, logs, lwt, mirage-types-lwt, vchan.xen)
+<lib/*>: package(cstruct, logs, lwt, mirage-types-lwt, vchan-xen)
 <lib/*.cm{x,o}> and not <lib/qubes.cmx>: for-pack(Qubes)
 <lib/ipv4/*>: package(mirage-protocols-lwt, ipaddr, lwt, tcpip.ipv4)
 <lib/formats.*>: package(cstruct.ppx)

--- a/opam
+++ b/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "cstruct" { >= "1.9.0" }
-  "vchan" { >= "2.3.0" }
+  "vchan-xen"
   "xen-evtchn"
   "xen-gnt"
   "mirage-xen" { >= "3.0.0" }


### PR DESCRIPTION
The optional sub package `vchan.xen` has been replaced with a real top-level `vchan-xen` package.