### PR TITLE
Qubes.GUI: More extensive support for GUId messages

### DIFF
--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -508,8 +508,8 @@ module QubesDB = struct
         | QDB_RESP_ERROR_NOENT
         | QDB_RESP_ERROR
         | QDB_RESP_READ
-        | QDB_RESP_MULTIREAD 
-        | QDB_RESP_LIST 
+        | QDB_RESP_MULTIREAD
+        | QDB_RESP_LIST
         | QDB_RESP_WATCH
         [@@uint8_t]
   ]

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -1,4 +1,5 @@
 (** The Qubes wire protocol details. *)
+(** for more details, see qubes-gui-common/include/qubes-gui-protocol.h *)
 
 open Utils
 
@@ -81,31 +82,415 @@ module Qrexec = struct
 end
 
 module GUI = struct
+  (** https://www.qubes-os.org/doc/gui/ *)
+  (** see qubes-gui-common/include/qubes-gui-protocol.h *)
+
+  let const_QUBES_MAIN_WINDOW = 1l
+
   [%%cstruct
       type gui_protocol_version = {
         version : uint32_t;
       } [@@little_endian]
   ]
 
+  (** struct msg_hdr *)
   [%%cstruct
       type msg_header = {
-        ty : uint32_t;
+        ty : uint32_t; (** type *)
         window : uint32_t;
+        untrusted_len : uint32_t;
+      } [@@little_endian]
+  ]
+
+  (** VM -> Dom0, Dom0 -> VM *)
+  [%%cstruct
+      type msg_map_info = {
+        override_redirect : uint32_t;
+        transient_for     : uint32_t;
+      } [@@little_endian]
+  ]
+
+  (** Dom0 -> VM, dom0 wants us to reply with a MSG_CLIPBOARD_DATA *)
+  [%%cstruct
+      type msg_clipboard_req = {
+        empty : uint8_t [@len 0]
       } [@@little_endian]
   ]
 
   [%%cstruct
-      type xconf = {
-        w : uint32_t;
-        h : uint32_t;
-        depth : uint32_t;
-        mem : uint32_t;
+      type msg_clipboard_data = {
+        len_big : uint32_t [@big_endian];
+        len_little : uint32_t;
+        (* followed by a uint8 array of size len *)
       } [@@little_endian]
   ]
+
+  (** VM -> Dom0 *)
+  [%%cstruct
+      type msg_create = {
+        x      : uint32_t; (* position of window, seems to be converted *)
+        y      : uint32_t;
+        width  : uint32_t;
+        height : uint32_t; (* from qubes src: "size of image" *)
+        parent : uint32_t;
+        override_redirect : uint32_t;
+      } [@@little_endian]
+  ]
+
+  type msg_keypress_t =
+    {
+        x     : int32;
+        y     : int32;
+        state : int32;
+        keycode : int32;
+    }
+
+  (** Dom0 -> VM *)
+  (* https://github.com/drinkcat/chroagh/commit/1d38c2e2422f97b6bf55580c9efc027ecf9f2721 *)
+  [%%cstruct
+      type msg_keypress = {
+        ty    : uint32_t; (* TODO *)
+        x     : uint32_t;
+        y     : uint32_t;
+        state : uint32_t; (** 1:down, 0:up *)
+        keycode : uint32_t;
+      } [@@little_endian]
+  ]
+
+  (** Dom0 -> VM, TODO seems to be mouse buttons? *)
+  [%%cstruct
+   type msg_button = {
+     ty : uint32_t;
+     x : uint32_t;
+     y : uint32_t;
+     state : uint32_t;
+     button : uint32_t; (* TODO *)
+   } [@@little_endian]
+  ]
+
+  (* dom0 -> VM, mouse / cursor movement *)
+  type msg_motion_t = {
+    x : int;
+    y : int;
+    state : int32;
+    is_hint : int;
+  }
+
+  (** Dom0 -> VM, mouse / cursor motion event *)
+  [%%cstruct
+      type msg_motion = {
+        x       : uint32_t;
+        y       : uint32_t;
+        state   : uint32_t;
+        is_hint : uint32_t;
+      } [@@little_endian]
+  ]
+
+  let decode_msg_motion cs : msg_motion_t option = (*TODO catch exceptions *)
+  let i32 = fun f -> (f cs |> Int32.to_int) in
+  Some ({
+      x = i32 get_msg_motion_x
+   ;  y = i32 get_msg_motion_y
+   ;  state  = get_msg_motion_state cs
+   ; is_hint = i32 get_msg_motion_is_hint
+   } : msg_motion_t)
+
+  (* Dom0 -> VM, TODO better types *)
+  type msg_crossing_t = {
+    ty : int32;
+    x  : int32;
+    y  : int32;
+    state  : int32;
+    mode   : int32;
+    detail : int32;
+    focus  : int32;
+  }
+
+  (** Dom0 -> VM, seems to fire when the mouse is moved over a window border *)
+  [%%cstruct
+   type msg_crossing = {
+     ty : uint32_t;
+     x  : uint32_t;
+     y  : uint32_t;
+     state  : uint32_t;
+     mode   : uint32_t;
+     detail : uint32_t;
+     focus  : uint32_t;
+   } [@@little_endian]
+  ]
+
+  let decode_msg_crossing cs  : msg_crossing_t option =
+     (*TODO catch exceptions *)
+    Some ({ ty = get_msg_crossing_ty cs
+          ;  x = get_msg_crossing_x  cs
+          ;  y = get_msg_crossing_y  cs
+          ;  state = get_msg_crossing_state  cs
+          ;   mode = get_msg_crossing_mode   cs
+          ; detail = get_msg_crossing_detail cs
+          ;  focus = get_msg_crossing_focus  cs
+          } : msg_crossing_t)
+
+  (** VM -> Dom0, Dom0 -> VM, note that when you send this you must read the
+                          "corrected" MSG_CONFIGURE you get back and use those
+                          values instead of your own *)
+  [%%cstruct
+      type msg_configure = {
+        x      : uint32_t;
+        y      : uint32_t;
+        width  : uint32_t;
+        height : uint32_t;
+        override_redirect : uint32_t;
+      } [@@little_endian]
+  ]
+
+  (** VM -> Dom0 *)
+  [%%cstruct
+   type msg_shmimage = {
+     x : uint32_t;
+     y : uint32_t;
+     width : uint32_t;
+     height: uint32_t;
+   } [@@little_endian]
+  ]
+
+  type msg_focus_t = {
+    mode : Cstruct.uint32;
+    detail: Cstruct.uint32;
+  }
+
+  (** Dom0 -> VM *)
+  [%%cstruct
+      type msg_focus = {
+        ty     : uint32_t;
+        mode   : uint32_t;
+        detail : uint32_t;
+      } [@@little_endian]
+  ]
+
+  (* Dom0 -> VM *)
+  [%%cstruct
+      type msg_execute = {
+        cmd: uint8_t [@len 255];
+      } [@@little_endian]
+  ]
+
+  (** Dom0 -> VM: Xorg conf *)
+  [%%cstruct
+      type xconf = {
+        w : uint32_t; (** width *)
+        h : uint32_t; (** height *)
+        depth : uint32_t; (** bits per pixel *)
+        mem : uint32_t; (* TODO seemingly unused , could be: MemBase baseaddress
+    This optional entry specifies the memory base address of a graphics board's
+    linear frame buffer. This entry is not used by many drivers, and it should
+    only be specified if the driver-specific documentation recommends it. *)
+      } [@@little_endian]
+  ]
+
+  (* https://tronche.com/gui/x/icccm/sec-4.html#WM_TRANSIENT_FOR *)
+
+  (** VM -> Dom0 *)
+  [%%cstruct
+      type msg_wmname = {
+        data : uint8_t  [@len 128]; (* title of the window *)
+      } [@@little_endian]
+  ]
+
+  (** Dom0 -> VM *)
+  [%%cstruct
+   type msg_keymap_notify = {
+     (* this is a 256-bit bitmap of which keys should be enabled*)
+     keys : uint8_t [@len 32];
+   } [@@little_endian]
+  ]
+
+  (** VM -> Dom0 *)
+  (* https://standards.freedesktop.org/wm-spec/latest/ *)
+  [%%cstruct
+   type msg_window_hints = {
+     flags : uint32_t;
+     min_width : uint32_t;
+     min_height: uint32_t;
+     max_width: uint32_t;
+     max_height: uint32_t;
+     width_inc: uint32_t;
+     height_inc: uint32_t;
+     base_width: uint32_t;
+     base_height: uint32_t;
+   } [@@little_endian]
+  ]
+
+  (** VM -> Dom0, Dom0 -> VM *)
+  [%%cstruct
+   type msg_window_flags = {
+     (* &1= FULLSCREEN, &2= DEMANDS_ATTENTION, &4=MINIMIZE *)
+     flags_set   : uint32_t;
+     flags_unset : uint32_t;
+   } [@@little_endian]
+  ]
+
+  (** VM -> Dom0 *)
+  [%%cstruct
+      type shm_cmd = {
+        shmid     : uint32_t;
+        width     : uint32_t;
+        height    : uint32_t;
+        bpp       : uint32_t; (* bpp = bits per pixel *)
+        off       : uint32_t;
+        num_mfn   : uint32_t; (* number of pixels *)
+        domid     : uint32_t;
+        (* followed by a variable length buffer of pixels:*)
+        (* uint32_t mfns[0]; *)
+      } [@@little_endian]
+  ]
+
+  (** VM -> Dom0 *)
+  [%%cstruct
+   type msg_wmclass = {
+     res_class : uint8_t [@len 64];
+     res_name : uint8_t [@len 64];
+   } [@@little_endian]
+  ]
+
+  [%%cenum
+    type msg_type =
+    (*| MSG_MIN [@id 123l] (* 0x7b_l *) *)
+    | MSG_KEYPRESS     [@id 124_l] (* 0x7c_l *)
+    | MSG_BUTTON       [@id 125_l]
+    | MSG_MOTION       [@id 126_l]
+    | MSG_CROSSING (* 0x7f_l *)
+    | MSG_FOCUS    (* 0x80_l *)
+    (*| MSG_RESIZE - DEPRECATED; NOT IMPLEMENTED *)
+    | MSG_CREATE        [@id 130_l] (* 0x82_l *)
+    | MSG_DESTROY
+    | MSG_MAP
+    | MSG_UNMAP         [@id 133_l] (* 0x85_l *)
+    | MSG_CONFIGURE     [@id 134_l] (* 0x86_l *)
+    | MSG_MFNDUMP
+    | MSG_SHMIMAGE
+    | MSG_CLOSE         [@id 137_l]
+    | MSG_EXECUTE
+    | MSG_CLIPBOARD_REQ
+    | MSG_CLIPBOARD_DATA
+    | MSG_WMNAME
+    | MSG_KEYMAP_NOTIFY
+    | MSG_DOCK          [@id 140_l] (* 0x8c_l *)
+    | MSG_WINDOW_HINTS
+    | MSG_WINDOW_FLAGS  [@id 142_l] (* 0x8e_l *)
+    | MSG_WMCLASS [@id 143_l] (* 0x8f_l *)
+    (*| MSG_MAX [@id 147l]*)
+    [@@uint32_t]
+  ]
+
+  let msg_type_size = function
+  | MSG_BUTTON -> Some sizeof_msg_button
+  | MSG_CLIPBOARD_REQ -> Some sizeof_msg_clipboard_req
+  | MSG_CLIPBOARD_DATA -> None
+  | MSG_CLOSE -> Some 0 (* user clicked [X] or pressed Alt-F4 or similar *)
+  | MSG_CONFIGURE -> Some sizeof_msg_configure
+  | MSG_CREATE -> Some sizeof_msg_create
+  | MSG_CROSSING -> Some sizeof_msg_crossing
+  | MSG_DESTROY ->
+    None (* this is the "prepare to shutdown your VM" message, no payload *)
+  | MSG_DOCK -> None (* TODO *)
+  | MSG_EXECUTE -> Some sizeof_msg_execute
+  | MSG_FOCUS -> Some sizeof_msg_focus
+  | MSG_KEYMAP_NOTIFY -> Some sizeof_msg_keymap_notify
+  | MSG_KEYPRESS -> Some sizeof_msg_keypress
+  | MSG_MAP -> None (* TODO *)
+  | MSG_MFNDUMP -> None (* TODO *)
+  | MSG_MOTION -> Some sizeof_msg_motion
+  | MSG_SHMIMAGE -> Some sizeof_msg_shmimage
+  | MSG_UNMAP -> None (* TODO *)
+  | MSG_WINDOW_FLAGS -> Some sizeof_msg_window_flags
+  | MSG_WINDOW_HINTS -> Some sizeof_msg_window_hints
+  | MSG_WMCLASS -> Some sizeof_msg_wmclass
+  | MSG_WMNAME -> Some sizeof_msg_wmname (* window title *)
+
+  (** "MFN: machine frame number - actual hw addresses"
+http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
+   *)
+  (* type mfn : uint32_t;  big-endian 24-bit RGB pixel *)
+
+  let make_with_header ?(window=const_QUBES_MAIN_WINDOW) ~ty body =
+    (** see qubes-gui-agent-linux/include/txrx.h:#define write_message *)
+    (** TODO consider using Cstruct.add_len *)
+    let body_len = Cstruct.len body in
+    let msg = Cstruct.create (sizeof_msg_header + body_len) in
+    let()= Cstruct.memset msg 0 in
+    let()= set_msg_header_ty     msg (msg_type_to_int ty) in
+    let()= set_msg_header_window msg window in
+    let()= set_msg_header_untrusted_len msg Int32.(of_int body_len) in
+    let() = Cstruct.blit
+        (* src, srcoff: *) body 0
+        (* dst, dstoff: *) msg sizeof_msg_header
+        (* length: *)      Cstruct.(len body)
+    in msg
+
+  let make_msg_mfndump ~domid ~width ~height ~mfns =
+    let num_mfn = List.length mfns in
+    let offset  = 0x0l in
+    let body = Cstruct.create (sizeof_shm_cmd + num_mfn*4) in
+    set_shm_cmd_shmid   body 0l; (* TODO what *)
+    set_shm_cmd_width   body height;
+    set_shm_cmd_height  body width;
+    set_shm_cmd_bpp     body 24l; (* bits per pixel *)
+    set_shm_cmd_off     body offset;
+    set_shm_cmd_num_mfn body Int32.(of_int num_mfn);
+    set_shm_cmd_domid   body Int32.(of_int domid);
+    (* TODO let n = (4 * width * height + offset
+                     + (XC_PAGE_SIZE-1)) / XC_PAGE_SIZE; *)
+    mfns |> List.iteri (fun i ->
+        Cstruct.LE.set_uint32 body (sizeof_shm_cmd + i*4));
+    let msg = make_with_header ~ty:MSG_MFNDUMP body in
+    msg
+
+  let make_msg_create ~width ~height ~x ~y ~override_redirect ~parent =
+    let body = Cstruct.create sizeof_msg_create in
+    set_msg_create_width             body width; (*  w *)
+    set_msg_create_height            body height; (* h *)
+    set_msg_create_x                 body x;
+    set_msg_create_y                 body y;
+    set_msg_create_override_redirect body override_redirect;
+    set_msg_create_parent            body parent;
+    make_with_header ~ty:MSG_CREATE body
+
+  let make_msg_map_info ~override_redirect ~transient_for =
+    let body = Cstruct.create sizeof_msg_map_info in
+    let()= set_msg_map_info_override_redirect body override_redirect in
+    let()= set_msg_map_info_transient_for body transient_for in
+    make_with_header ~ty:MSG_MAP body
+
+  let make_msg_wmname ~wmname =
+    let body = Cstruct.create sizeof_msg_wmname in
+    let()= Cstruct.blit_from_string wmname 0 body 0
+      (min String.(length wmname) sizeof_msg_wmname) ; (* length *) in
+    make_with_header ~ty:MSG_WMNAME body
+
+  let make_msg_window_hints ~width ~height =
+    let body = Cstruct.create sizeof_msg_window_hints in
+    set_msg_window_hints_flags body Int32.(16 lor 32 |> of_int) ;
+       (*^--  PMinSize | PMaxSize *)
+    set_msg_window_hints_min_width body width;
+    set_msg_window_hints_min_height body height;
+    set_msg_window_hints_max_width body width;
+    set_msg_window_hints_max_height body height;
+    make_with_header ~ty:MSG_WINDOW_HINTS body
+
+  let make_msg_configure ~x ~y ~width ~height =
+    let body  = Cstruct.create sizeof_msg_configure in
+    set_msg_configure_x body x ;
+    set_msg_configure_y body y ; (* x and y are from qs->window_x and window_y*)
+
+    set_msg_configure_width body width ;
+    set_msg_configure_height body height ;
+    set_msg_configure_override_redirect body 0l ;
+    make_with_header ~ty:MSG_CONFIGURE body
 
   module Framing = struct
     let header_size = sizeof_msg_header
-    let body_size_from_header _h = raise (error "GUI: body_size_from_header: TODO")
+    let body_size_from_header _h =
+      get_msg_header_untrusted_len _h |> Int32.to_int
   end
 end
 

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -432,8 +432,8 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
     let offset  = 0x0l in
     let body = Cstruct.create (sizeof_shm_cmd + num_mfn*4) in
     set_shm_cmd_shmid   body 0l; (* TODO what *)
-    set_shm_cmd_width   body height;
-    set_shm_cmd_height  body width;
+    set_shm_cmd_width   body width;
+    set_shm_cmd_height  body height;
     set_shm_cmd_bpp     body 24l; (* bits per pixel *)
     set_shm_cmd_off     body offset;
     set_shm_cmd_num_mfn body Int32.(of_int num_mfn);

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -10,7 +10,9 @@ module QV = Msg_chan.Make(Framing)
 let src = Logs.Src.create "qubes.gui" ~doc:"Qubes GUId agent"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let qubes_gui_protocol_version_linux = 0x10000l
+(* QUBES_GUID_PROTOCOL_VERSION_MAJOR << 16 | QUBES_GUID_PROTOCOL_VERSION_MINOR
+   see ./qubes-gui-common/include/qubes-gui-protocol.h *)
+let qubes_gui_protocol_version_linux = Int32.logor 0x1_0000_l 0x0001_l
 
 let gui_agent_port =
   match Vchan.Port.of_string "6000" with
@@ -22,6 +24,7 @@ type t = QV.t
 let connect ~domid () =
   Log.info (fun f -> f "waiting for client...");
   QV.server ~domid ~port:gui_agent_port () >>= fun gui ->
+  (* qubesgui_init_connection *)
   let version = Cstruct.create sizeof_gui_protocol_version in
   set_gui_protocol_version_version version qubes_gui_protocol_version_linux;
   QV.send gui [version] >>= function
@@ -30,14 +33,120 @@ let connect ~domid () =
   QV.recv_fixed gui sizeof_xconf >>= function
   | `Eof -> Lwt.fail (error "End-of-file getting X configuration")
   | `Ok conf ->
-  let w = get_xconf_w conf in
-  let h = get_xconf_h conf in
-  Log.info (fun f -> f "client connected (screen size: %ldx%ld)" w h);
+  let screen_w = get_xconf_w conf in
+  let screen_h = get_xconf_h conf in
+  let xdepth = get_xconf_depth conf in
+  let xmem = get_xconf_mem conf in
+  Log.info (fun f ->
+      f "client connected (screen size: %ldx%ld depth: %ld mem: %ldx)"
+        screen_w screen_h xdepth xmem);
   Lwt.return gui
 
+let decode_KEYPRESS buf =
+    let keypress : Formats.GUI.msg_keypress_t = {
+      x = get_msg_keypress_x buf;
+      y = get_msg_keypress_y buf;
+      state = get_msg_keypress_state buf;
+      keycode = get_msg_keypress_keycode buf;
+    } in
+    Log.warn (fun f ->
+        f "Got a keypress ty: %ld x: %ld y: %ld state: %ld keycode: %ld"
+             (get_msg_keypress_ty buf)
+             keypress.Formats.GUI.x keypress.y keypress.state keypress.keycode)
+
+let decode_FOCUS buf =
+  let focus : Formats.GUI.msg_focus_t = {
+    mode = get_msg_focus_mode buf;
+    detail = get_msg_focus_detail buf;
+  } in
+  Log.warn (fun f ->
+      f "Focus event: mode: %ld detail: %ld" focus.mode focus.detail)
+
+let decode_DESTROY buf =
+  Log.warn (fun f -> f "DESTROY event: %s" (Cstruct.to_string buf))
+
+let decode_CLOSE buf =
+  Log.warn (fun f -> f "CLOSE event: %s" (Cstruct.to_string buf))
+
+let decode_CLIPBOARD_DATA buf =
+  Log.warn (fun f ->
+      f "Event: Received clipboard data from dom0: %S" (Cstruct.to_string buf))
+
+let decode_MSG_MOTION buf =
+   let Some m = Formats.GUI.decode_msg_motion buf in
+   Log.warn (fun f -> f "Motion event: x: %d y: %d state: %ld is_hint: %d"
+                m.x m.y m.state m.is_hint)
+
+let decode_MSG_CROSSING buf =
+  let Some m = decode_msg_crossing buf in
+  Log.warn (fun f -> f "Event: CROSSING: type: %ld x: %ld y: %ld" m.ty m.x m.y)
+
 let rec listen t =
-  QV.recv_raw t >>= function
+  QV.recv t >>= function
   | `Eof -> failwith "End-of-file from GUId in dom0"
-  | `Ok buf ->
-      Log.warn (fun f -> f "Unexpected data: %S" (Cstruct.to_string buf));
-      listen t
+  | `Ok (msg_header , msg_buf) ->
+  let msg_window = get_msg_header_window msg_header |> Int32.to_int in
+  let msg_len    = get_msg_header_untrusted_len msg_header |> Int32.to_int in
+  begin match int_to_msg_type (get_msg_header_ty msg_header) with
+
+  (* handle fixed-length messages *)
+
+  | Some ( MSG_KEYPRESS | MSG_BUTTON | MSG_MOTION | MSG_CROSSING | MSG_FOCUS
+         | MSG_CREATE | MSG_DESTROY | MSG_CONFIGURE | MSG_SHMIMAGE
+         | MSG_EXECUTE | MSG_WMNAME | MSG_KEYMAP_NOTIFY | MSG_WINDOW_HINTS
+         | MSG_WINDOW_FLAGS | MSG_WMCLASS | MSG_CLIPBOARD_REQ
+         | MSG_CLOSE as msg)
+      when msg_len <> (match msg_type_size msg with Some x -> x | None -> -1) ->
+      Log.warn (fun f -> f "BUG: expected_size [%d] <> msg_len [%d] for fixed-\
+                            size msg! msg_header: %S Received raw buffer:: %S"
+                         (match msg_type_size msg with Some x -> x | None -> -1)
+                         msg_len
+                         Cstruct.(to_string msg_header)
+                         Cstruct.(to_string msg_buf))
+  | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
+  | Some MSG_FOCUS -> decode_FOCUS msg_buf
+  | Some MSG_MOTION -> ignore @@ decode_msg_motion msg_buf
+  | Some MSG_CLIPBOARD_REQ ->
+    Log.warn (fun f ->
+        f "Event: dom0 requested our clipboard. debug: sizeof: %d"
+          sizeof_msg_clipboard_req)
+  | Some MSG_CROSSING -> ignore @@ decode_msg_crossing msg_buf
+  | Some MSG_DESTROY ->
+    Log.warn (fun f -> f "Event: DESTROY: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_CLOSE -> Log.warn (fun f -> f "Event: CLOSE window %d" msg_window)
+  | Some MSG_BUTTON ->
+    Log.warn (fun f -> f "Event: BUTTON: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_CREATE ->
+    Log.warn (fun f -> f "Event: CREATE: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_EXECUTE ->
+    Log.warn (fun f -> f "Event: EXECUTE: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_WMNAME ->
+    Log.warn (fun f -> f "Event: WMNAME: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_KEYMAP_NOTIFY ->
+    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_WINDOW_HINTS ->
+    Log.warn (fun f -> f "Event: WINDOW_HINTS: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_WINDOW_FLAGS ->
+    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_CONFIGURE ->
+    Log.warn (fun f -> f "Event: CONFIGURE: %S" Cstruct.(to_string msg_buf))
+  | Some MSG_SHMIMAGE
+  | Some MSG_WMCLASS  ->
+    Log.warn (fun f -> f "Event: Unhandled fixed-length: %S"
+                 Cstruct.(to_string msg_buf))
+
+  (* parse variable-length messages: *)
+
+  | Some MSG_CLIPBOARD_DATA -> decode_CLIPBOARD_DATA msg_buf
+
+  (* handle unimplemented/unexpected messages:*)
+
+  | Some (MSG_MAP|MSG_UNMAP|MSG_MFNDUMP|MSG_DOCK) ->
+    Log.warn (fun f ->
+        f "UNHANDLED DATA of non-fixed length received. Data: %S"
+          Cstruct.(to_string msg_buf))
+  | None ->
+    Log.warn (fun f -> f "Unexpected data with unknown type: [%S]%S"
+                 (Cstruct.to_string msg_header) (Cstruct.to_string msg_buf))
+  end
+  ; listen t


### PR DESCRIPTION
This adds constants and ctypes required for implementing graphical user interface from Mirage.
It also adds a good amount of debug logging that will normally not be shown unless you register a window with Qubes' GUId, but I can remove that if you wish.