### PR TITLE
RExec: strip "nogui:" prefix

### DIFF
--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -178,7 +178,18 @@ let parse_cmdline cmd =
     let cmd = String.sub cmd 0 (String.length cmd - 1) in
     match cmd |> split ':' with
     | None -> fail (error "Missing ':' in %S" cmd)
-    | Some (user, cmd) -> return (user, cmd)
+    | Some (user, cmd) ->
+      (* Strip ["nogui:"] prefix; it's a Windows thing *)
+      let nogui = "nogui:" in
+      match String.sub cmd 0 (String.length nogui) with
+      | "nogui:" ->
+        let cmd = String.sub cmd
+            (String.length nogui) (String.length cmd - String.length nogui) in
+        return (user, cmd)
+      | _ ->
+        return (user, cmd)
+      | exception Invalid_argument _ ->
+        return (user, cmd)
   )
 
 let exec t ~ty ~handler msg =


### PR DESCRIPTION
Qubes sometimes add a `nogui:` prefix to qrexec commands. From the source code of the linux agent it seems to be a thing for Windows VMs, and the linux agent strips this prefix without further ado.

See comment in `do_exec()` in qubes-core-agent-linux:qrexec/qrexec-agent.c

Please do not merge yet, I haven't tested yet - I'm opening this PR as a reminder for myself and/or discussion. (sorry)