### PR TITLE
remove ethif type from IPv4 implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - PACKAGE=mirage-qubes
+  - PINS="mirage-qubes.dev:. mirage-qubes-ipv4.dev:."
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
-  - OCAML_VERSION=4.03
-  - OCAML_VERSION=4.03 DEPOPTS="ipaddr tcpip"
-  - OCAML_VERSION=4.04
-  - OCAML_VERSION=4.04 DEPOPTS="ipaddr tcpip"
+  - OCAML_VERSION=4.04 PACKAGE=mirage-qubes
+  - OCAML_VERSION=4.04 PACKAGE=mirage-qubes-ipv4
+  - OCAML_VERSION=4.05 PACKAGE=mirage-qubes
+  - OCAML_VERSION=4.05 PACKAGE=mirage-qubes-ipv4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - PACKAGE=mirage-qubes EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+  - PACKAGE=mirage-qubes
+  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.03 DEPOPTS="ipaddr tcpip"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+### 0.6 (2018-09-16)
+
+- qrexec message chunking (#21 @reynir)
+- more extensive support of Qubes GUI protocol (#17 @cfcs, #20 @reynir)
+- Adjust to tcpip 3.5.0 and mirage-protocols-lwt 1.4.0 changes mirage-qubes-ipv4
+  Static_ipv4.Make now requires a Random device and a monotonic clock
+  connect requires a Mclock.t
+  Mirage_protocols_lwt.IPV4 does not define the type alias ethif (#24 @hannesm)
+
 ### 0.5 (2017-06-15)
 
 - Split into 2 opam packages: mirage-qubes and mirage-qubes-ipv4

--- a/lib/ipv4/jbuild
+++ b/lib/ipv4/jbuild
@@ -1,6 +1,6 @@
 (library
  ((name qubesdb_ipv4)
   (public_name mirage-qubes-ipv4)
-  (libraries (cstruct lwt mirage-types-lwt logs tcpip tcpip.ipv4 ipaddr mirage-protocols-lwt mirage-qubes))
+  (libraries (cstruct lwt mirage-types-lwt logs tcpip tcpip.ipv4 ipaddr mirage-protocols-lwt mirage-qubes mirage-clock mirage-random))
 ))
 

--- a/lib/ipv4/qubesdb_ipv4.ml
+++ b/lib/ipv4/qubesdb_ipv4.ml
@@ -1,9 +1,11 @@
-module Make(D: Qubes.S.DB)
-  (Ethernet : Mirage_protocols_lwt.ETHIF)
-  (Arp : Mirage_protocols_lwt.ARP) = struct
-  module IP = Static_ipv4.Make(Ethernet)(Arp)
-  include IP
-  let connect db ethif arp =
+module Make
+    (D: Qubes.S.DB)
+    (R: Mirage_random.C)
+    (C: Mirage_clock.MCLOCK)
+    (Ethernet : Mirage_protocols_lwt.ETHIF)
+    (Arp : Mirage_protocols_lwt.ARP) = struct
+  include Static_ipv4.Make(R)(C)(Ethernet)(Arp)
+  let connect db clock ethif arp =
     let (>>=?) ip f = match ip with
       | None -> None
       | Some s -> f s
@@ -13,6 +15,6 @@ module Make(D: Qubes.S.DB)
     match ip with
     | Some ip ->
       let network = Ipaddr.V4.Prefix.make 32 ip in
-      IP.connect ~ip ~network ~gateway ethif arp
+      connect ~ip ~network ~gateway clock ethif arp
     | _ -> Lwt.fail_with "couldn't get ip configuration from qubesdb"
 end

--- a/lib/ipv4/qubesdb_ipv4.mli
+++ b/lib/ipv4/qubesdb_ipv4.mli
@@ -1,12 +1,15 @@
-module Make(D : Qubes.S.DB)
-           (Ethernet : Mirage_protocols_lwt.ETHIF)
-           (Arp : Mirage_protocols_lwt.ARP) : sig
+module Make
+    (D : Qubes.S.DB)
+    (R : Mirage_random.C)
+    (C : Mirage_clock.MCLOCK)
+    (Ethernet : Mirage_protocols_lwt.ETHIF)
+    (Arp : Mirage_protocols_lwt.ARP) : sig
 
-  include Mirage_protocols_lwt.IPV4 with type ethif = Ethernet.t
-  val connect : D.t -> Ethernet.t -> Arp.t -> t io
-  (** [connect db ethernet arp] attempts to use the provided [db] 
+  include Mirage_protocols_lwt.IPV4
+  val connect : D.t -> C.t -> Ethernet.t -> Arp.t -> t io
+  (** [connect db clock ethernet arp] attempts to use the provided [db]
    *  to look up the correct IPV4 information, and construct
-   *  an ipv4 implementation based on [ethernet] and [arp].  If [db]
+   *  an ipv4 implementation based on [clock], [ethernet] and [arp].  If [db]
    *  can't be read or doesn't contain useful values, [connect] will
    *  raise a failure. *)
 end

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -15,9 +15,11 @@ build: [
 depends: [
   "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
-  "mirage-qubes"
-  "tcpip"
+  "mirage-qubes" { >= "0.6" }
+  "tcpip" { >= "3.5.0" }
   "ipaddr"
+  "mirage-random"
+  "mirage-clock"
   "mirage-protocols-lwt"
   "cstruct" { >= "1.9.0" }
   "lwt"


### PR DESCRIPTION
this is not needed, see https://github.com/mirage/mirage-protocols/pull/11