### PR TITLE
Guid windows 20190307

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### v0.7.0 (2019-03-06)
+
+- mirage-qubes-ipv4: compatibility with mirage-protocols 2.0.0 and mirage-net 2.0.0
+  (#31 @yomimono)
+
 ### 0.6.1 (2019-01-17)
 
 - mirage-qubes-ipv4: compatibility with ipaddr 3.0.0 (#29 @hannesm)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### 0.6.1 (2019-01-17)
+
+- mirage-qubes-ipv4: compatibility with ipaddr 3.0.0 (#29 @hannesm)
+- upgrade opam files to version 2.0
+
 ### 0.6 (2018-09-16)
 
 - qrexec message chunking (#21 @reynir)

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name mirage-qubes)

--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,6 @@
  (name qubes)
  (public_name mirage-qubes)
  (libraries cstruct vchan-xen xen-evtchn xen-gnt mirage-xen lwt
-   mirage-types-lwt logs)
+   logs)
  (preprocess
-  (pps cstruct.ppx)))
+  (pps ppx_cstruct)))

--- a/lib/dune
+++ b/lib/dune
@@ -1,0 +1,7 @@
+(library
+ (name qubes)
+ (public_name mirage-qubes)
+ (libraries cstruct vchan-xen xen-evtchn xen-gnt mirage-xen lwt
+   mirage-types-lwt logs)
+ (preprocess
+  (pps cstruct.ppx)))

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -117,13 +117,8 @@ module GUI = struct
       } [@@little_endian]
   ]
 
-  [%%cstruct
-      type msg_clipboard_data = {
-        len_big : uint32_t [@big_endian];
-        len_little : uint32_t;
-        (* followed by a uint8 array of size len *)
-      } [@@little_endian]
-  ]
+  (** Dom0 -> VM, VM -> Dom0: MSG_CLIPBOARD_DATA:*)
+  (** a normal header, followed by a uint8 array of size len *)
 
   (** VM -> Dom0 *)
   [%%cstruct

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -157,6 +157,14 @@ module GUI = struct
       } [@@little_endian]
   ]
 
+  type msg_button_t = {
+   ty : int32 ;
+    x : int32 ;
+    y : int32 ;
+    state : int32 ;
+    button: int32 ;
+  }
+
   (** Dom0 -> VM, TODO seems to be mouse buttons? *)
   [%%cstruct
    type msg_button = {
@@ -167,6 +175,14 @@ module GUI = struct
      button : uint32_t; (* TODO *)
    } [@@little_endian]
   ]
+
+  let decode_msg_button cs : msg_button_t option =
+    Some ({ ty = get_msg_button_ty cs ;
+            x = get_msg_button_x cs ;
+            y = get_msg_button_y cs ;
+            state = get_msg_button_state cs ;
+            button = get_msg_button_button cs ;
+      })
 
   (* dom0 -> VM, mouse / cursor movement *)
   type msg_motion_t = {
@@ -412,7 +428,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
    *)
   (* type mfn : uint32_t;  big-endian 24-bit RGB pixel *)
 
-  let make_with_header ?(window=const_QUBES_MAIN_WINDOW) ~ty body =
+  let make_with_header ~window ~ty body =
     (** see qubes-gui-agent-linux/include/txrx.h:#define write_message *)
     (** TODO consider using Cstruct.add_len *)
     let body_len = Cstruct.len body in

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -556,17 +556,19 @@ module QubesDB = struct
 end
 
 module Rpc_filecopy = struct
-  (* see qubes-linux-utils/qrexec-lib/libqubes-rpc-filecopy.h *)
+  (* see qubes-linux-utils/qrexec-lib/libqubes-rpc-filecopy.h
+   * and qubes-core-agent-windows/src/qrexec-services/common/filecopy.h*)
   [%%cstruct
       type file_header = {
-        namelen    : uint32; (* TODO these uint32 are really "unsigned int" *)
+        namelen    : uint32;
         mode       : uint32;
-        filelen    : uint64; (* unsigned long long *)
+        filelen    : uint64;
         atime      : uint32;
         atime_nsec : uint32;
         mtime      : uint32;
         mtime_nsec : uint32;
       } [@@little_endian]
+      (* followed by filename[namelen] and data[filelen] *)
   ]
 
   [%%cstruct
@@ -587,7 +589,7 @@ module Rpc_filecopy = struct
   let make_result_header_ext last_filename =
     let namelen = Cstruct.len last_filename in
     let msg = Cstruct.create (sizeof_result_header_ext + namelen) in
-    set_result_header_ext_last_namelen msg namelen;
+    set_result_header_ext_last_namelen msg (Int32.of_int namelen);
     Cstruct.blit (* src  srcoff *) last_filename 0
                  (* dst  dstoff *) msg sizeof_result_header_ext
                  (* len *) namelen ;

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -583,9 +583,9 @@ module Rpc_filecopy = struct
    * and qubes-core-agent-windows/src/qrexec-services/common/filecopy.h*)
   [%%cstruct
       type file_header = {
-        namelen    : uint32; (* TODO these uint32 are really "unsigned int" *)
+        namelen    : uint32;
         mode       : uint32;
-        filelen    : uint64; (* unsigned long long *)
+        filelen    : uint64;
         atime      : uint32;
         atime_nsec : uint32;
         mtime      : uint32;

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -253,7 +253,23 @@ module GUI = struct
         height : uint32_t;
         override_redirect : uint32_t;
       } [@@little_endian]
-  ]
+    ]
+
+  type msg_configure_t = {
+    x: int32;
+    y: int32;
+    width: int32;
+    height: int32;
+    override_redirect: int32;
+  }
+
+  let decode_msg_configure cs : msg_configure_t option =
+    Some ({ x = get_msg_configure_x cs ;
+            y = get_msg_configure_y cs ;
+            width = get_msg_configure_width cs ;
+            height = get_msg_configure_height cs ;
+            override_redirect = get_msg_configure_override_redirect cs ;
+          } : msg_configure_t)
 
   (** VM -> Dom0 *)
   [%%cstruct

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -583,9 +583,9 @@ module Rpc_filecopy = struct
    * and qubes-core-agent-windows/src/qrexec-services/common/filecopy.h*)
   [%%cstruct
       type file_header = {
-        namelen    : uint32;
+        namelen    : uint32; (* TODO these uint32 are really "unsigned int" *)
         mode       : uint32;
-        filelen    : uint64;
+        filelen    : uint64; (* unsigned long long *)
         atime      : uint32;
         atime_nsec : uint32;
         mtime      : uint32;

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -205,6 +205,7 @@ let rec listen t () =
     Log.err (fun f -> f "Event: WMNAME: %S" Cstruct.(to_string msg_buf)) ;
     UNIT ()
   | Some MSG_KEYMAP_NOTIFY ->
+    (* Synchronize the keyboard state (key pressed/released) with dom0 *)
     Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %S" Cstruct.(to_string msg_buf))
     ;UNIT()
   | Some MSG_WINDOW_HINTS ->

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -19,18 +19,127 @@ let gui_agent_port =
   | `Error msg -> failwith msg
   | `Ok port -> port
 
-type t = QV.t
+type event =
+  | UNIT of unit (* placeholder for unimplemented events *)
+  | Keypress of msg_keypress_t
+  | Focus of msg_focus_t
+  | Motion of msg_motion_t
+  | Clipboard_request
+  | Clipboard_data of Cstruct.t
+  | Window_crossing of msg_crossing_t
+  | Window_destroy
+  | Window_close
+  | Button of msg_button_t
+
+let pp_event fmt event =
+  let pf() = Format.fprintf fmt in
+  match event with
+  | UNIT () -> pf() "UNIT"
+  | Button _ -> pf() "Button"
+  | Clipboard_request -> pf() "Clipboard_request"
+  | Clipboard_data cs -> pf() "Clipboard_data: %S" (Cstruct.to_string cs)
+  | Focus {mode;detail} -> pf() "Focus mode: %ld detail: %ld" mode detail
+  | Keypress {x;y;state;keycode} ->
+    pf() "Keypress x: %ld y: %ld state: %ld keycode: %ld" x y state keycode
+  | Motion m -> pf() "Motion x: %d y: %d state: %ld is_hint: %d"
+                      m.x m.y m.state m.is_hint
+  | Window_close -> pf() "Window_close"
+  | Window_crossing {ty;x;y} ->
+    pf() "Window_crossing type type: %ld x: %ld y: %ld" ty x y
+  | Window_destroy -> pf() "Window_destroy"
+
+type window_id = Cstruct.uint32
+type window = {no : window_id ; mvar : event Lwt_mvar.t ; qv : QV.t }
+type t = { qv : QV.t ;
+           mutable mvar : window list}
+
+let decode_KEYPRESS buf =
+    let keypress : Formats.GUI.msg_keypress_t = {
+      x = get_msg_keypress_x buf;
+      y = get_msg_keypress_y buf;
+      state = get_msg_keypress_state buf;
+      keycode = get_msg_keypress_keycode buf;
+    } in
+    Keypress keypress
+
+let decode_FOCUS buf =
+  let focus : Formats.GUI.msg_focus_t = {
+    mode = get_msg_focus_mode buf;
+    detail = get_msg_focus_detail buf;
+  } in
+  Focus focus
+
+let decode_MSG_DESTROY buf =
+  Log.warn (fun f -> f "Event: DESTROY: %a" Cstruct.hexdump_pp buf) ;
+  Window_destroy
+
+let decode_MSG_CLOSE buf =
+  Log.warn (fun f -> f "Event: CLOSE: %a" Cstruct.hexdump_pp buf) ;
+  Window_close
+
+let decode_CLIPBOARD_DATA buf = Clipboard_data buf
+
+let decode_MSG_MOTION buf =
+   let Some m = Formats.GUI.decode_msg_motion buf in
+   Motion m
+
+let decode_MSG_CROSSING buf =
+  let Some m = decode_msg_crossing buf in
+  Window_crossing m
+
+let decode_MSG_BUTTON buf =
+  Log.warn (fun f -> f "Event: BUTTON: %a" Cstruct.hexdump_pp buf) ;
+  let Some m = decode_msg_button buf in Button m
+
+let recv_event (window:window) =
+  Lwt_mvar.take window.mvar
+
+let debug_window w =
+  let rec loop () = recv_event w >>= fun e ->
+    Log.info (fun m -> m "debug_window [%ld]: %a" w.no pp_event e);
+    loop ()
+  in loop
+
+let send t cs_lst = QV.send t.qv cs_lst
+
+let set_title (window : window) title =
+  QV.send window.qv
+  [Formats.GUI.make_msg_wmname ~window:window.no ~wmname:title]
+
+let int32_of_window (w : window) : int32 = w.no
+
+let create_window ?(parent=(0l:window_id)) ~width ~height t
+  : window S.or_eof Lwt.t =
+  let w : window = { no = List.length t.mvar |> Int32.of_int ;
+                     mvar = Lwt_mvar.create_empty () ;
+                     qv = t.qv }
+  in
+  let window = w.no in
+  Logs.warn (fun m -> m "Qubes.GUI: Creating new window id %ld" window);
+  t.mvar <- w :: t.mvar ;
+  let messages =
+    let override_redirect = 0l in
+    [Formats.GUI.make_msg_create ~width ~height ~x:0l ~y:0l
+       ~override_redirect ~parent:0l ~window ;
+     Formats.GUI.make_msg_map_info ~override_redirect ~transient_for:0l ~window;
+     Formats.GUI.make_msg_wmname ~window ~wmname:"my window" ;
+     Formats.GUI.make_msg_configure ~width ~height ~x:0l ~y:0l ~window ;
+    ]
+  in
+  send t messages
+  >>= function | `Ok () -> Lwt.return (`Ok w)
+               | `Eof -> Lwt.return `Eof
 
 let connect ~domid () =
   Log.info (fun f -> f "waiting for client...");
-  QV.server ~domid ~port:gui_agent_port () >>= fun gui ->
+  QV.server ~domid ~port:gui_agent_port () >>= fun qv ->
   (* qubesgui_init_connection *)
   let version = Cstruct.create sizeof_gui_protocol_version in
   set_gui_protocol_version_version version qubes_gui_protocol_version_linux;
-  QV.send gui [version] >>= function
+  QV.send qv [version] >>= function
   | `Eof -> Lwt.fail (error "End-of-file sending protocol version")
   | `Ok () ->
-  QV.recv_fixed gui sizeof_xconf >>= function
+  QV.recv_fixed qv sizeof_xconf >>= function
   | `Eof -> Lwt.fail (error "End-of-file getting X configuration")
   | `Ok conf ->
   let screen_w = get_xconf_w conf in
@@ -40,53 +149,24 @@ let connect ~domid () =
   Log.info (fun f ->
       f "client connected (screen size: %ldx%ld depth: %ld mem: %ldx)"
         screen_w screen_h xdepth xmem);
-  Lwt.return gui
+  let main_window = {no = 0l ; qv ; mvar = Lwt_mvar.create_empty ()} in
+  Lwt.async (debug_window main_window) ;
+  Lwt.return { qv ;
+               mvar = [main_window] }
 
-let decode_KEYPRESS buf =
-    let keypress : Formats.GUI.msg_keypress_t = {
-      x = get_msg_keypress_x buf;
-      y = get_msg_keypress_y buf;
-      state = get_msg_keypress_state buf;
-      keycode = get_msg_keypress_keycode buf;
-    } in
-    Log.warn (fun f ->
-        f "Got a keypress ty: %ld x: %ld y: %ld state: %ld keycode: %ld"
-             (get_msg_keypress_ty buf)
-             keypress.Formats.GUI.x keypress.y keypress.state keypress.keycode)
-
-let decode_FOCUS buf =
-  let focus : Formats.GUI.msg_focus_t = {
-    mode = get_msg_focus_mode buf;
-    detail = get_msg_focus_detail buf;
-  } in
-  Log.warn (fun f ->
-      f "Focus event: mode: %ld detail: %ld" focus.mode focus.detail)
-
-let decode_DESTROY buf =
-  Log.warn (fun f -> f "DESTROY event: %s" (Cstruct.to_string buf))
-
-let decode_CLOSE buf =
-  Log.warn (fun f -> f "CLOSE event: %s" (Cstruct.to_string buf))
-
-let decode_CLIPBOARD_DATA buf =
-  Log.warn (fun f ->
-      f "Event: Received clipboard data from dom0: %S" (Cstruct.to_string buf))
-
-let decode_MSG_MOTION buf =
-   let Some m = Formats.GUI.decode_msg_motion buf in
-   Log.warn (fun f -> f "Motion event: x: %d y: %d state: %ld is_hint: %d"
-                m.x m.y m.state m.is_hint)
-
-let decode_MSG_CROSSING buf =
-  let Some m = decode_msg_crossing buf in
-  Log.warn (fun f -> f "Event: CROSSING: type: %ld x: %ld y: %ld" m.ty m.x m.y)
-
-let rec listen t =
-  QV.recv t >>= function
+let rec listen t () =
+  QV.recv t.qv >>= function
   | `Eof -> failwith "End-of-file from GUId in dom0"
   | `Ok (msg_header , msg_buf) ->
-  let msg_window = get_msg_header_window msg_header |> Int32.to_int in
+  let window = get_msg_header_window msg_header in
+  let send_to_window =
+    match List.find (fun t -> t.no = window) t.mvar with
+    | w -> Lwt_mvar.put w.mvar
+    | exception _ -> Log.warn (fun m -> m "No such window %ld" window);
+                     fun _ -> Lwt.return ()
+  in
   let msg_len    = get_msg_header_untrusted_len msg_header |> Int32.to_int in
+  send_to_window @@
   begin match int_to_msg_type (get_msg_header_ty msg_header) with
 
   (* handle fixed-length messages *)
@@ -102,38 +182,43 @@ let rec listen t =
                          (match msg_type_size msg with Some x -> x | None -> -1)
                          msg_len
                          Cstruct.(to_string msg_header)
-                         Cstruct.(to_string msg_buf))
+                         Cstruct.(to_string msg_buf)); UNIT ()
   | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
   | Some MSG_FOCUS -> decode_FOCUS msg_buf
-  | Some MSG_MOTION -> ignore @@ decode_msg_motion msg_buf
+  | Some MSG_MOTION -> decode_MSG_MOTION msg_buf
   | Some MSG_CLIPBOARD_REQ ->
     Log.warn (fun f ->
         f "Event: dom0 requested our clipboard. debug: sizeof: %d"
-          sizeof_msg_clipboard_req)
-  | Some MSG_CROSSING -> ignore @@ decode_msg_crossing msg_buf
-  | Some MSG_DESTROY ->
-    Log.warn (fun f -> f "Event: DESTROY: %S" Cstruct.(to_string msg_buf))
-  | Some MSG_CLOSE -> Log.warn (fun f -> f "Event: CLOSE window %d" msg_window)
-  | Some MSG_BUTTON ->
-    Log.warn (fun f -> f "Event: BUTTON: %S" Cstruct.(to_string msg_buf))
+          sizeof_msg_clipboard_req) ; Clipboard_request
+  | Some MSG_CROSSING -> decode_MSG_CROSSING msg_buf
+  | Some MSG_DESTROY -> decode_MSG_DESTROY msg_buf
+  | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
+  | Some MSG_BUTTON -> decode_MSG_BUTTON msg_buf
   | Some MSG_CREATE ->
-    Log.warn (fun f -> f "Event: CREATE: %S" Cstruct.(to_string msg_buf))
+    Log.warn (fun f -> f "Event: CREATE: %S" Cstruct.(to_string msg_buf));
+    UNIT ()
   | Some MSG_EXECUTE ->
-    Log.warn (fun f -> f "Event: EXECUTE: %S" Cstruct.(to_string msg_buf))
-  | Some MSG_WMNAME ->
-    Log.warn (fun f -> f "Event: WMNAME: %S" Cstruct.(to_string msg_buf))
+    Log.warn (fun f -> f "Event: EXECUTE: %S" Cstruct.(to_string msg_buf));
+    UNIT ()
+  | Some MSG_WMNAME -> (* TODO VM -> dom0 only*)
+    Log.err (fun f -> f "Event: WMNAME: %S" Cstruct.(to_string msg_buf)) ;
+    UNIT ()
   | Some MSG_KEYMAP_NOTIFY ->
     Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %S" Cstruct.(to_string msg_buf))
+    ;UNIT()
   | Some MSG_WINDOW_HINTS ->
     Log.warn (fun f -> f "Event: WINDOW_HINTS: %S" Cstruct.(to_string msg_buf))
+    ;UNIT()
   | Some MSG_WINDOW_FLAGS ->
     Log.warn (fun f -> f "Event: WINDOW_FLAGS: %S" Cstruct.(to_string msg_buf))
+    ; UNIT()
   | Some MSG_CONFIGURE ->
-    Log.warn (fun f -> f "Event: CONFIGURE: %S" Cstruct.(to_string msg_buf))
+    Log.warn (fun f -> f "Event: CONFIGURE: %a" Cstruct.hexdump_pp msg_buf)
+    ; UNIT()
   | Some MSG_SHMIMAGE
   | Some MSG_WMCLASS  ->
     Log.warn (fun f -> f "Event: Unhandled fixed-length: %S"
-                 Cstruct.(to_string msg_buf))
+                 Cstruct.(to_string msg_buf)); UNIT()
 
   (* parse variable-length messages: *)
 
@@ -143,10 +228,12 @@ let rec listen t =
 
   | Some (MSG_MAP|MSG_UNMAP|MSG_MFNDUMP|MSG_DOCK) ->
     Log.warn (fun f ->
-        f "UNHANDLED DATA of non-fixed length received. Data: %S"
-          Cstruct.(to_string msg_buf))
+        f "UNHANDLED DATA of non-fixed length received. Data: %a"
+          Cstruct.hexdump_pp msg_buf); UNIT()
   | None ->
-    Log.warn (fun f -> f "Unexpected data with unknown type: [%S]%S"
-                 (Cstruct.to_string msg_header) (Cstruct.to_string msg_buf))
+    Log.warn (fun f -> f "Unexpected data with unknown type: [%a] %aa"
+                 Cstruct.hexdump_pp msg_header
+                 Cstruct.hexdump_pp msg_buf) ;
+    UNIT()
   end
-  ; listen t
+  >>= fun () -> listen t ()

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -59,6 +59,7 @@ let decode_KEYPRESS buf =
       y = get_msg_keypress_y buf;
       state = get_msg_keypress_state buf;
       keycode = get_msg_keypress_keycode buf;
+      ty = get_msg_keypress_ty buf;
     } in
     Keypress keypress
 

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -227,8 +227,8 @@ let rec listen t () =
   | Some MSG_CONFIGURE ->
     Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a"
                  Cstruct.hexdump_pp msg_buf) ;
-    (* TODO here we are ACK'ing to Qubes that we accept the new dimensions -
-            perhaps the user should have a say in that: *)
+    (* TODO here we should ACK to Qubes that we accept the new dimensions,
+            atm this is the responsibility of the user: *)
     decode_CONFIGURE msg_buf
 
   (* parse variable-length messages: *)

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -95,24 +95,6 @@ let decode_MSG_MOTION buf =
     Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: %a" Cstruct.hexdump_pp buf);
     UNIT ()
 
-let _decode_MSG_CROSSING buf =
-  match decode_msg_crossing buf with
-  | Some m ->
-    Log.warn (fun f -> f "Event: CROSSING: type: %ld x: %ld y: %ld" m.ty m.x m.y);
-    Window_crossing m
-  | None ->
-    Log.warn (fun f -> f "attempted to decode a crossing event, but we were not successful: %a" Cstruct.hexdump_pp buf);
-    UNIT ()
-
-let _decode_MSG_BUTTON buf =
-  match decode_msg_button buf with
-  | Some m ->
-    Log.warn (fun f -> f "Event: BUTTON: type: %ld x: %ld y: %ld" m.ty m.x m.y);
-    Button m
-  | None ->
-    Log.warn (fun f -> f "attempted to decode a button event, but we were not successful: %a" Cstruct.hexdump_pp buf) ;
-    UNIT ()
-
 let decode_CONFIGURE buf =
   match decode_msg_configure buf with
   | Some m -> Configure m
@@ -223,13 +205,15 @@ let rec listen t () =
     Clipboard_request
   | Some MSG_CROSSING -> begin match decode_msg_crossing msg_buf with
       | Some event -> Window_crossing event
-      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding")
+      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding %a"
+                             Cstruct.hexdump_pp msg_buf)
               ; UNIT ()
       end
   | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
   | Some MSG_BUTTON -> begin match decode_msg_button msg_buf with
       | Some button_event -> Button button_event
-      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding")
+      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding %a"
+                             Cstruct.hexdump_pp msg_buf)
         ; UNIT ()
       end
   | Some MSG_KEYMAP_NOTIFY ->

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -26,6 +26,7 @@ type event =
   | Motion of msg_motion_t
   | Clipboard_request
   | Clipboard_data of Cstruct.t
+  | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy
   | Window_close
@@ -38,6 +39,8 @@ let pp_event fmt event =
   | Button _ -> pf() "Button"
   | Clipboard_request -> pf() "Clipboard_request"
   | Clipboard_data cs -> pf() "Clipboard_data: %S" (Cstruct.to_string cs)
+  | Configure x -> pf() "Configure: @[x=%ld;@ y=%ld;@ width=%ld;@ height=%ld@]"
+                     x.x x.y x.width x.height
   | Focus {mode;detail} -> pf() "Focus mode: %ld detail: %ld" mode detail
   | Keypress {x;y;state;keycode; ty = _ } ->
     pf() "Keypress x: %ld y: %ld state: %ld keycode: %ld" x y state keycode
@@ -76,9 +79,50 @@ let decode_MSG_CLOSE buf =
   Log.warn (fun f -> f "Event: CLOSE: %a" Cstruct.hexdump_pp buf) ;
   Window_close
 
-let decode_CLIPBOARD_DATA buf =
-  Log.warn (fun f -> f "Event: CLIPBOARD_DATA: %a" Cstruct.hexdump_pp buf);
-  Clipboard_data buf
+let decode_CLIPBOARD_DATA buf = Clipboard_data buf
+
+let int32_of_window (w : window) : int32 = w.no
+
+
+let decode_MSG_DESTROY buf =
+  Log.warn (fun f -> f "Event: DESTROY: %s" (Cstruct.to_string buf)) ;
+  Window_destroy
+
+let decode_MSG_MOTION buf =
+  match Formats.GUI.decode_msg_motion buf with
+  | Some m ->
+    Log.warn (fun f -> f "Motion event: x: %d y: %d state: %ld is_hint: %d"
+                 m.x m.y m.state m.is_hint);
+    Motion m
+  | None ->
+    Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: %a" Cstruct.hexdump_pp buf);
+    UNIT ()
+
+let decode_MSG_CROSSING buf =
+  match decode_msg_crossing buf with
+  | Some m ->
+    Log.warn (fun f -> f "Event: CROSSING: type: %ld x: %ld y: %ld" m.ty m.x m.y);
+    Window_crossing m
+  | None ->
+    Log.warn (fun f -> f "attempted to decode a crossing event, but we were not successful: %a" Cstruct.hexdump_pp buf);
+    UNIT ()
+
+let decode_MSG_BUTTON buf =
+  match decode_msg_button buf with
+  | Some m ->
+    Log.warn (fun f -> f "Event: BUTTON: type: %ld x: %ld y: %ld" m.ty m.x m.y);
+    Button m
+  | None ->
+    Log.warn (fun f -> f "attempted to decode a button event, but we were not successful: %a" Cstruct.hexdump_pp buf) ;
+    UNIT ()
+
+let decode_CONFIGURE buf =
+  match decode_msg_configure buf with
+  | Some m -> Configure m
+  | None ->
+    Log.warn (fun f -> f "failed decoding CONFIGURE message from dom0: %a"
+                 Cstruct.hexdump_pp buf) ;
+    UNIT ()
 
 let recv_event (window:window) =
   Lwt_mvar.take window.mvar
@@ -94,30 +138,6 @@ let send t cs_lst = QV.send t.qv cs_lst
 let set_title (window : window) title =
   QV.send window.qv
   [Formats.GUI.make_msg_wmname ~window:window.no ~wmname:title]
-
-let int32_of_window (w : window) : int32 = w.no
-
-let create_window ?(parent=(0l:window_id)) ~x ~y ~title ~width ~height t
-  : window S.or_eof Lwt.t =
-  let w : window = { no = List.length t.mvar |> Int32.of_int ;
-                     mvar = Lwt_mvar.create_empty () ;
-                     qv = t.qv }
-  in
-  let window = w.no in
-  Logs.warn (fun m -> m "Qubes.GUI: Creating new window id %ld" window);
-  t.mvar <- w :: t.mvar ;
-  let messages =
-    let override_redirect = 0l in
-    [Formats.GUI.make_msg_create ~width ~height ~x ~y
-       ~override_redirect ~parent ~window ;
-     Formats.GUI.make_msg_map_info ~override_redirect ~transient_for:0l ~window;
-     Formats.GUI.make_msg_wmname ~window ~wmname:title ;
-     Formats.GUI.make_msg_configure ~width ~height ~x ~y ~window ;
-    ]
-  in
-  send t messages
-  >>= function | `Ok () -> Lwt.return (`Ok w)
-               | `Eof -> Lwt.return `Eof
 
 let connect ~domid () =
   Log.info (fun f -> f "waiting for client...");
@@ -143,17 +163,38 @@ let connect ~domid () =
   Lwt.return { qv ;
                mvar = [main_window] }
 
+let create_window ?(parent=(0l:window_id)) ~x ~y ~title ~width ~height t
+  : window S.or_eof Lwt.t =
+  let w : window = { no = List.length t.mvar |> Int32.of_int ;
+                     mvar = Lwt_mvar.create_empty () ;
+                     qv = t.qv }
+  in
+  let window = w.no in
+  Logs.warn (fun m -> m "Qubes.GUI: Creating new window id %ld" window);
+  t.mvar <- w :: t.mvar ;
+  let messages =
+    let override_redirect = 0l in
+    [Formats.GUI.make_msg_create ~width ~height ~x ~y
+       ~override_redirect ~parent ~window ;
+     Formats.GUI.make_msg_map_info ~override_redirect ~transient_for:0l ~window;
+     Formats.GUI.make_msg_wmname ~window ~wmname:title ;
+     Formats.GUI.make_msg_configure ~width ~height ~x ~y ~window ;
+    ]
+  in
+  send t messages
+  >>= function | `Ok () -> Lwt.return (`Ok w)
+               | `Eof -> Lwt.return `Eof
+
 let rec listen t () =
   QV.recv t.qv >>= function
   | `Eof -> failwith "End-of-file from GUId in dom0"
   | `Ok (msg_header , msg_buf) ->
   let window = get_msg_header_window msg_header in
-  let send_to_window promise =
-    promise >>= fun resolved ->
+  let send_to_window =
     match List.find (fun t -> t.no = window) t.mvar with
-    | w -> Lwt_mvar.put w.mvar resolved
+    | w -> Lwt_mvar.put w.mvar
     | exception _ -> Log.warn (fun m -> m "No such window %ld" window);
-                     Lwt.return ()
+                     fun _ -> Lwt.return ()
   in
   let msg_len    = get_msg_header_untrusted_len msg_header |> Int32.to_int in
   send_to_window
@@ -173,48 +214,55 @@ let rec listen t () =
                          (match msg_type_size msg with Some x -> x | None -> -1)
                          msg_len
                          Cstruct.hexdump_pp msg_header
-                         Cstruct.hexdump_pp msg_buf); Lwt.return (UNIT ())
-  | Some MSG_KEYPRESS -> Lwt.return @@ decode_KEYPRESS msg_buf
-  | Some MSG_FOCUS -> Lwt.return @@ decode_FOCUS msg_buf
-  | Some MSG_MOTION -> begin match decode_msg_motion msg_buf with
-      | Some event -> Lwt.return @@ Motion event
-      | None -> Lwt.fail_with "Invalid MSG_MOTION during decoding"
-      end
-  | Some MSG_CLIPBOARD_REQ ->
-    Log.warn (fun f -> f "Event: dom0 requested our clipboard.") ;
-    Lwt.return Clipboard_request
-  | Some MSG_CROSSING -> begin match decode_msg_crossing msg_buf with
-      | Some event -> Lwt.return @@ Window_crossing event
-      | None -> Lwt.fail_with "Invalid MSG_CROSSING during decoding"
-      end
-  | Some MSG_CLOSE -> Lwt.return @@ decode_MSG_CLOSE msg_buf
-  | Some MSG_BUTTON -> begin match decode_msg_button msg_buf with
-      | Some button_event -> Lwt.return (Button button_event)
-      | None -> Lwt.fail_with "Invalid MSG_BUTTON decoding"
-      end
-  | Some MSG_KEYMAP_NOTIFY ->
-    (* Synchronize the keyboard state (key pressed/released) with dom0 *)
-    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %S"
-      Cstruct.(to_string msg_buf)) ;
-    Lwt.return @@ UNIT()
-  | Some MSG_WINDOW_FLAGS ->
-    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %S" Cstruct.(to_string msg_buf))
-      ; Lwt.return @@ UNIT ()
-  | Some MSG_CONFIGURE ->
-    Log.warn (fun f -> f "Event: CONFIGURE: %a" Cstruct.hexdump_pp msg_buf) ;
-    (* TODO here we are ACK'ing to Qubes that we accept the new dimensions -
-            perhaps the user should have a say in that: *)
-    QV.send t.qv [msg_header; msg_buf] >>= begin function
-        | `Ok () -> Lwt.return @@ UNIT ()
-        | `Eof -> Lwt.fail_with "EOF"
-      end
+                         Cstruct.hexdump_pp msg_buf)
+      ; UNIT()
   | Some MSG_MAP ->
     Log.warn (fun f -> f "Event: MAP: %a" Cstruct.hexdump_pp msg_buf)
-    ; Lwt.return @@ UNIT()
+    ; UNIT()
+  | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
+  | Some MSG_FOCUS -> decode_FOCUS msg_buf
+  | Some MSG_MOTION -> decode_MSG_MOTION msg_buf
+  | Some MSG_CLIPBOARD_REQ ->
+    Log.warn (fun f ->
+        f "Event: dom0 requested our clipboard. debug: sizeof: %d"
+          sizeof_msg_clipboard_req) ; Clipboard_request
+  | Some MSG_CROSSING -> decode_MSG_CROSSING msg_buf
+  | Some MSG_DESTROY -> decode_MSG_DESTROY msg_buf
+  | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
+  | Some MSG_BUTTON -> decode_MSG_BUTTON msg_buf
+  | Some MSG_CREATE ->
+    Log.warn (fun f -> f "Event: CREATE: %S" Cstruct.(to_string msg_buf));
+    UNIT ()
+  | Some MSG_EXECUTE ->
+    Log.warn (fun f -> f "Event: EXECUTE: %S" Cstruct.(to_string msg_buf));
+    UNIT ()
+  | Some MSG_WMNAME -> (* TODO VM -> dom0 only*)
+    Log.err (fun f -> f "Event: WMNAME: %S" Cstruct.(to_string msg_buf)) ;
+    UNIT ()
+  | Some MSG_KEYMAP_NOTIFY ->
+    (* Synchronize the keyboard state (key pressed/released) with dom0 *)
+    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %S" Cstruct.(to_string msg_buf))
+    ;UNIT()
+  | Some MSG_WINDOW_HINTS ->
+    Log.warn (fun f -> f "Event: WINDOW_HINTS: %S" Cstruct.(to_string msg_buf))
+    ;UNIT()
+  | Some MSG_WINDOW_FLAGS ->
+    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %S" Cstruct.(to_string msg_buf))
+    ; UNIT()
+  | Some MSG_CONFIGURE ->
+    Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a"
+                 Cstruct.hexdump_pp msg_buf) ;
+    (* TODO here we are ACK'ing to Qubes that we accept the new dimensions -
+            perhaps the user should have a say in that: *)
+    decode_CONFIGURE msg_buf
+  | Some MSG_SHMIMAGE
+  | Some MSG_WMCLASS  ->
+    Log.warn (fun f -> f "Event: Unhandled fixed-length: %S"
+                 Cstruct.(to_string msg_buf)); UNIT()
 
   (* parse variable-length messages: *)
 
-  | Some MSG_CLIPBOARD_DATA -> Lwt.return @@ decode_CLIPBOARD_DATA msg_buf
+  | Some MSG_CLIPBOARD_DATA -> decode_CLIPBOARD_DATA msg_buf
 
   (* handle unimplemented/unexpected messages:*)
 
@@ -224,12 +272,12 @@ let rec listen t () =
     (* Handle messages that are appvm->dom0 and thus dom0 is not supposed
        to send to the VM: *)
     Log.warn (fun f ->
-        f "UNEXPECTED message received. Data: %a"
-          Cstruct.hexdump_pp msg_buf); Lwt.return @@ UNIT()
+        f "UNHANDLED DATA of non-fixed length received. Data: %a"
+          Cstruct.hexdump_pp msg_buf); UNIT()
   | None ->
     Log.warn (fun f -> f "Unexpected data with unknown type: [%a] %aa"
                  Cstruct.hexdump_pp msg_header
                  Cstruct.hexdump_pp msg_buf) ;
-    Lwt.return @@ UNIT()
+    UNIT()
   end
   >>= fun () -> listen t ()

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -227,28 +227,15 @@ let rec listen t () =
         f "Event: dom0 requested our clipboard. debug: sizeof: %d"
           sizeof_msg_clipboard_req) ; Clipboard_request
   | Some MSG_CROSSING -> decode_MSG_CROSSING msg_buf
-  | Some MSG_DESTROY -> decode_MSG_DESTROY msg_buf
   | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
   | Some MSG_BUTTON -> decode_MSG_BUTTON msg_buf
-  | Some MSG_CREATE ->
-    Log.warn (fun f -> f "Event: CREATE: %S" Cstruct.(to_string msg_buf));
-    UNIT ()
-  | Some MSG_EXECUTE ->
-    Log.warn (fun f -> f "Event: EXECUTE: %S" Cstruct.(to_string msg_buf));
-    UNIT ()
-  | Some MSG_WMNAME -> (* TODO VM -> dom0 only*)
-    Log.err (fun f -> f "Event: WMNAME: %S" Cstruct.(to_string msg_buf)) ;
-    UNIT ()
   | Some MSG_KEYMAP_NOTIFY ->
     (* Synchronize the keyboard state (key pressed/released) with dom0 *)
     Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %S" Cstruct.(to_string msg_buf))
     ;UNIT()
-  | Some MSG_WINDOW_HINTS ->
-    Log.warn (fun f -> f "Event: WINDOW_HINTS: %S" Cstruct.(to_string msg_buf))
-    ;UNIT()
   | Some MSG_WINDOW_FLAGS ->
     Log.warn (fun f -> f "Event: WINDOW_FLAGS: %S" Cstruct.(to_string msg_buf))
-    ; UNIT()
+      ; UNIT ()
   | Some MSG_CONFIGURE ->
     Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a"
                  Cstruct.hexdump_pp msg_buf) ;
@@ -272,7 +259,7 @@ let rec listen t () =
     (* Handle messages that are appvm->dom0 and thus dom0 is not supposed
        to send to the VM: *)
     Log.warn (fun f ->
-        f "UNHANDLED DATA of non-fixed length received. Data: %a"
+        f "UNEXPECTED message received. Data: %a"
           Cstruct.hexdump_pp msg_buf); UNIT()
   | None ->
     Log.warn (fun f -> f "Unexpected data with unknown type: [%a] %aa"

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -79,7 +79,9 @@ let decode_MSG_CLOSE buf =
   Log.warn (fun f -> f "Event: CLOSE: %a" Cstruct.hexdump_pp buf) ;
   Window_close
 
-let decode_CLIPBOARD_DATA buf = Clipboard_data buf
+let decode_CLIPBOARD_DATA buf =
+  Log.warn (fun f -> f "Event: CLIPBOARD_DATA: %a" Cstruct.hexdump_pp buf);
+  Clipboard_data buf
 
 let int32_of_window (w : window) : int32 = w.no
 
@@ -207,25 +209,22 @@ let rec listen t () =
          | MSG_EXECUTE | MSG_WMNAME | MSG_KEYMAP_NOTIFY | MSG_WINDOW_HINTS
          | MSG_WINDOW_FLAGS | MSG_WMCLASS | MSG_CLIPBOARD_REQ
          | MSG_CLOSE as msg)
-    when (begin match msg_type_size msg with Some x -> x <> msg_len
-                                           | None -> false end) ->
-      Log.warn (fun f -> f "BUG: expected_size [%d] <> msg_len [%d] for fixed-\
-                            size msg! msg_header: %a@ Received raw buffer:: %a"
-                         (match msg_type_size msg with Some x -> x | None -> -1)
-                         msg_len
-                         Cstruct.hexdump_pp msg_header
-                         Cstruct.hexdump_pp msg_buf)
-      ; UNIT()
+    when (match msg_type_size msg with Some x -> x <> msg_len | None -> true) ->
+    Log.warn (fun f -> f "BUG: expected_size [%d] <> msg_len [%d] for fixed-\
+                          size msg! msg_header: %a@ Received raw buffer:: %a"
+                 (match msg_type_size msg with Some x -> x | None -> -1)
+                 msg_len
+                 Cstruct.hexdump_pp msg_header
+                 Cstruct.hexdump_pp msg_buf) ;
+    UNIT()
   | Some MSG_MAP ->
-    Log.warn (fun f -> f "Event: MAP: %a" Cstruct.hexdump_pp msg_buf)
-    ; UNIT()
+    Log.warn (fun f -> f "Event: MAP: %a" Cstruct.hexdump_pp msg_buf) ;
+    UNIT()
   | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
   | Some MSG_FOCUS -> decode_FOCUS msg_buf
   | Some MSG_MOTION -> decode_MSG_MOTION msg_buf
   | Some MSG_CLIPBOARD_REQ ->
-    Log.warn (fun f ->
-        f "Event: dom0 requested our clipboard. debug: sizeof: %d"
-          sizeof_msg_clipboard_req) ; Clipboard_request
+    Log.warn (fun f -> f "Event: dom0 requested our clipboard.") ; Clipboard_request
   | Some MSG_CROSSING -> decode_MSG_CROSSING msg_buf
   | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
   | Some MSG_BUTTON -> decode_MSG_BUTTON msg_buf

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -4,7 +4,49 @@
 (** The Qubes GUI agent *)
 
 type t
+type window_id
+type window
+
+open Formats.GUI
+
+type event =
+  | UNIT of unit
+  | Keypress of Formats.GUI.msg_keypress_t
+  | Focus of msg_focus_t
+  | Motion of msg_motion_t
+  | Clipboard_request
+  | Clipboard_data of Cstruct.t
+  | Window_crossing of msg_crossing_t
+  | Window_destroy
+  | Window_close
+  | Button of msg_button_t
+
+val pp_event : Format.formatter -> event -> unit
+(** [pp_event formatter event] pretty-prints an event. *)
 
 val connect : domid:int -> unit -> t Lwt.t
+(** [connect domid ()] connects to the guid in the given [domid] over Vchan. *)
 
-val listen : t -> 'a Lwt.t
+val listen : t -> unit -> t Lwt.t
+(** [listen ti ()] is an event listener thread. It can be run with Lwt.async
+                   and will never return. Events are dispatched to windows
+                   created using [create_window].*)
+
+val set_title : window -> string -> unit S.or_eof Lwt.t
+val int32_of_window : window -> int32
+
+val create_window : ?parent:window_id -> width:Cstruct.uint32 ->
+                    height:Cstruct.uint32 -> t-> window S.or_eof Lwt.t
+(* [create_window ?parent ~width ~height t] instantiates a new window. *)
+
+val send : t -> Cstruct.t list -> unit S.or_eof Lwt.t
+(** [send t messages] synchronously sends [messages] to the Qubes GUId
+                      using [t]'s established vchan *)
+
+val recv_event : window -> event Lwt.t
+(** [recv_event] is a blocking Lwt thread that can be called repeatedly to
+                 read new events coming in on [window] *)
+
+val debug_window : window -> unit -> unit Lwt.t
+(** [debug_window] is a window "handler" to be called with Lwt.async
+                   that pretty-prints the received events.*)

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -35,9 +35,14 @@ val listen : t -> unit -> t Lwt.t
 val set_title : window -> string -> unit S.or_eof Lwt.t
 val int32_of_window : window -> int32
 
-val create_window : ?parent:window_id -> width:Cstruct.uint32 ->
-                    height:Cstruct.uint32 -> t-> window S.or_eof Lwt.t
-(* [create_window ?parent ~width ~height t] instantiates a new window. *)
+val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
+  title:string ->
+  width:Cstruct.uint32 ->
+  height:Cstruct.uint32 -> t-> window S.or_eof Lwt.t
+(** [create_window ?parent ~title ~width ~height t] instantiates a new window.
+    The window will have dimensions [width] * [height], and be instantiated at
+    coordinates [x]*[y] (relative to the screen's [0,0]).
+*)
 
 val send : t -> Cstruct.t list -> unit S.or_eof Lwt.t
 (** [send t messages] synchronously sends [messages] to the Qubes GUId

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -35,6 +35,7 @@ val listen : t -> unit -> t Lwt.t
 val set_title : window -> string -> unit S.or_eof Lwt.t
 val int32_of_window : window -> int32
 
+<<<<<<< HEAD
 val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
   title:string ->
   width:Cstruct.uint32 ->
@@ -43,6 +44,11 @@ val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
     The window will have dimensions [width] * [height], and be instantiated at
     coordinates [x]*[y] (relative to the screen's [0,0]).
 *)
+=======
+val create_window : ?parent:window_id -> width:Cstruct.uint32 ->
+                    height:Cstruct.uint32 -> t-> window S.or_eof Lwt.t
+(* [create_window ?parent ~width ~height t] instantiates a new window. *)
+>>>>>>> adab1b7... Qubes.GUI: Implement event dispatch from GUI thread using Lwt_mvar
 
 val send : t -> Cstruct.t list -> unit S.or_eof Lwt.t
 (** [send t messages] synchronously sends [messages] to the Qubes GUId

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -16,6 +16,7 @@ type event =
   | Motion of msg_motion_t
   | Clipboard_request
   | Clipboard_data of Cstruct.t
+  | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy
   | Window_close

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -35,7 +35,6 @@ val listen : t -> unit -> t Lwt.t
 val set_title : window -> string -> unit S.or_eof Lwt.t
 val int32_of_window : window -> int32
 
-<<<<<<< HEAD
 val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
   title:string ->
   width:Cstruct.uint32 ->
@@ -44,11 +43,6 @@ val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
     The window will have dimensions [width] * [height], and be instantiated at
     coordinates [x]*[y] (relative to the screen's [0,0]).
 *)
-=======
-val create_window : ?parent:window_id -> width:Cstruct.uint32 ->
-                    height:Cstruct.uint32 -> t-> window S.or_eof Lwt.t
-(* [create_window ?parent ~width ~height t] instantiates a new window. *)
->>>>>>> adab1b7... Qubes.GUI: Implement event dispatch from GUI thread using Lwt_mvar
 
 val send : t -> Cstruct.t list -> unit S.or_eof Lwt.t
 (** [send t messages] synchronously sends [messages] to the Qubes GUId

--- a/lib/ipv4/dune
+++ b/lib/ipv4/dune
@@ -1,0 +1,5 @@
+(library
+ (name qubesdb_ipv4)
+ (public_name mirage-qubes-ipv4)
+ (libraries cstruct lwt mirage-types-lwt logs tcpip tcpip.ipv4 ipaddr
+   mirage-protocols-lwt mirage-qubes mirage-clock mirage-random))

--- a/lib/ipv4/dune
+++ b/lib/ipv4/dune
@@ -1,5 +1,5 @@
 (library
  (name qubesdb_ipv4)
  (public_name mirage-qubes-ipv4)
- (libraries cstruct lwt mirage-types-lwt logs tcpip tcpip.ipv4 ipaddr
+ (libraries cstruct lwt logs tcpip tcpip.ipv4 ipaddr
    mirage-protocols-lwt mirage-qubes mirage-clock mirage-random))

--- a/lib/ipv4/jbuild
+++ b/lib/ipv4/jbuild
@@ -1,6 +1,0 @@
-(library
- ((name qubesdb_ipv4)
-  (public_name mirage-qubes-ipv4)
-  (libraries (cstruct lwt mirage-types-lwt logs tcpip tcpip.ipv4 ipaddr mirage-protocols-lwt mirage-qubes mirage-clock mirage-random))
-))
-

--- a/lib/ipv4/qubesdb_ipv4.ml
+++ b/lib/ipv4/qubesdb_ipv4.ml
@@ -7,14 +7,18 @@ module Make
   include Static_ipv4.Make(R)(C)(Ethernet)(Arp)
   let connect db clock ethif arp =
     let (>>=?) ip f = match ip with
-      | None -> None
+      | None -> Error (`Msg "couldn't read qubesdb")
       | Some s -> f s
     in
     let ip = D.read db "/qubes-ip" >>=? Ipaddr.V4.of_string in
-    let gateway = D.read db "/qubes-gateway" >>=? Ipaddr.V4.of_string in
+    let gateway = match D.read db "/qubes-gateway" >>=? Ipaddr.V4.of_string with
+      | Ok ip -> Some ip
+      | Error _ -> None
+    in
     match ip with
-    | Some ip ->
+    | Ok ip ->
       let network = Ipaddr.V4.Prefix.make 32 ip in
       connect ~ip ~network ~gateway clock ethif arp
-    | _ -> Lwt.fail_with "couldn't get ip configuration from qubesdb"
+    | Error (`Msg m) ->
+      Lwt.fail_with ("couldn't get ip configuration from qubesdb: " ^ m)
 end

--- a/lib/ipv4/qubesdb_ipv4.ml
+++ b/lib/ipv4/qubesdb_ipv4.ml
@@ -2,7 +2,7 @@ module Make
     (D: Qubes.S.DB)
     (R: Mirage_random.C)
     (C: Mirage_clock.MCLOCK)
-    (Ethernet : Mirage_protocols_lwt.ETHIF)
+    (Ethernet : Mirage_protocols_lwt.ETHERNET)
     (Arp : Mirage_protocols_lwt.ARP) = struct
   include Static_ipv4.Make(R)(C)(Ethernet)(Arp)
   let connect db clock ethif arp =

--- a/lib/ipv4/qubesdb_ipv4.mli
+++ b/lib/ipv4/qubesdb_ipv4.mli
@@ -2,7 +2,7 @@ module Make
     (D : Qubes.S.DB)
     (R : Mirage_random.C)
     (C : Mirage_clock.MCLOCK)
-    (Ethernet : Mirage_protocols_lwt.ETHIF)
+    (Ethernet : Mirage_protocols_lwt.ETHERNET)
     (Arp : Mirage_protocols_lwt.ARP) : sig
 
   include Mirage_protocols_lwt.IPV4

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,7 +1,0 @@
-(library
- ((name qubes)
-  (public_name mirage-qubes)
-  (libraries (cstruct vchan-xen xen-evtchn xen-gnt mirage-xen lwt mirage-types-lwt logs))
-  (preprocess (pps (cstruct.ppx)))
-))
-

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "dune"  {build & >= "1.0"}
-  "mirage-qubes" { >= "0.6" }
+  "mirage-qubes" { >= "0.7.0" }
   "tcpip" { >= "3.5.0" }
   "ipaddr" { >= "3.0.0" }
   "mirage-random"

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -13,7 +13,6 @@ build: [
 ]
 
 depends: [
-  "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
   "mirage-qubes" { >= "0.6" }
   "tcpip" { >= "3.5.0" }

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder"  {build & >="1.0+beta9"}
   "mirage-qubes" { >= "0.6" }
   "tcpip" { >= "3.5.0" }
-  "ipaddr"
+  "ipaddr" { >= "3.0.0" }
   "mirage-random"
   "mirage-clock"
   "mirage-protocols-lwt"

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -19,10 +19,9 @@ depends: [
   "ipaddr" { >= "3.0.0" }
   "mirage-random"
   "mirage-clock"
-  "mirage-protocols-lwt"
+  "mirage-protocols-lwt" { >= "2.0.0" }
   "cstruct" { >= "1.9.0" }
   "lwt"
-  "mirage-types-lwt" { >= "3.0.0" }
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.03.0" }
 ]

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -8,12 +8,12 @@ dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
 doc:          "https://mirage.github.io/mirage-qubes"
 
 build: [
-  [ "jbuilder" "subst" "-p" name] {pinned}
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
 depends: [
-  "jbuilder"  {build & >="1.0+beta9"}
+  "dune"  {build & >= "1.0"}
   "mirage-qubes" { >= "0.6" }
   "tcpip" { >= "3.5.0" }
   "ipaddr" { >= "3.0.0" }

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -16,6 +16,7 @@ depends: [
   "dune"  {build & >= "1.0"}
   "cstruct" { >= "1.9.0" }
   "ppx_cstruct"
+  "mirage-protocols-lwt" { >= "2.0.0" }
   "vchan-xen"
   "xen-evtchn"
   "xen-gnt"

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -8,12 +8,12 @@ doc:          "https://mirage.github.io/mirage-qubes"
 license:      "BSD-2-Clause"
 
 build: [
-  [ "jbuilder" "subst" "-p" name] {pinned}
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
 depends: [
-  "jbuilder"  {build & >="1.0+beta9"}
+  "dune"  {build & >= "1.0"}
   "cstruct" { >= "1.9.0" }
   "vchan-xen"
   "xen-evtchn"

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "dune"  {build & >= "1.0"}
   "cstruct" { >= "1.9.0" }
+  "mirage-protocols-lwt" { >= "2.0.0" }
   "vchan-xen"
   "xen-evtchn"
   "xen-gnt"

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -13,7 +13,6 @@ build: [
 ]
 
 depends: [
-  "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
   "cstruct" { >= "1.9.0" }
   "vchan-xen"

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -15,13 +15,12 @@ build: [
 depends: [
   "dune"  {build & >= "1.0"}
   "cstruct" { >= "1.9.0" }
-  "mirage-protocols-lwt" { >= "2.0.0" }
+  "ppx_cstruct"
   "vchan-xen"
   "xen-evtchn"
   "xen-gnt"
   "mirage-xen" { >= "3.0.0" }
   "lwt"
-  "mirage-types-lwt" { >= "3.0.0" }
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.03.0" }
 ]


### PR DESCRIPTION
This is kind of a mess history-wise, but it should incorporate:

- jbuilder -> dune transition ( @yomimono )
- recent 0.7.0 changes
  - ip / ethernet changes ( @hannesm )
- GUI:
  - window support
  - docstrings
- types for the *"RPC filecopy"* API ([basic example here](https://github.com/cfcs/eye-of-mirage/blob/master/command.ml#L15-L61) )

I read through the diff and I think it makes sense, but please let me know if I missed something.
ping @talex5 @yomimono @reynir @hannesm