### PR TITLE
Implement `request_service` and some attendant changes

### DIFF
--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -80,10 +80,26 @@ module Qrexec = struct
     | `Exec_cmdline -> 0x200l
     | `Just_exec -> 0x201l
     | `Service_connect -> 0x202l
+    | `Service_refused -> 0x203l
     | `Trigger_service -> 0x210l
     | `Connection_terminated -> 0x211l
     | `Hello -> 0x300l
     | `Unknown x -> x
+
+  let string_of_type = function
+    | `Data_stdin -> "DATA_STDIN"
+    | `Data_stdout -> "DATA_STDOUT"
+    | `Data_stderr -> "DATA_STDERR"
+    | `Data_exit_code -> "DATA_EXIT_CODE"
+    | `Exec_cmdline -> "MSG_EXEC_CMDLINE"
+    | `Just_exec -> "MSG_JUST_EXEC"
+    | `Service_connect -> "MSG_SERVICE_CONNECT"
+    | `Service_refused -> "MSG_SERVICE_REFUSED"
+    | `Trigger_service -> "MSG_TRIGGER_SERVICE"
+    | `Connection_terminated -> "MSG_CONNECTION_TERMINATED"
+    | `Hello -> "MSG_HELLO"
+    | `Unknown x -> "Unknown message: " ^ (Int32.to_string x)
+
 
   module Framing = struct
     let header_size = sizeof_msg_header

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -37,10 +37,19 @@ module Qrexec = struct
       } [@@little_endian]
   ]
 
+  [%%cstruct
+    type trigger_service_params = {
+      service_name : uint8_t [@len 64];
+      target_domain : uint8_t [@len 32];
+      request_id : uint8_t [@len 32]
+    } [@@little_endian]
+  ]
+
   type msg_type =
     [ `Exec_cmdline
     | `Just_exec
     | `Service_connect
+    | `Service_refused
     | `Trigger_service
     | `Connection_terminated
     | `Hello
@@ -57,6 +66,7 @@ module Qrexec = struct
     | 0x200l -> `Exec_cmdline
     | 0x201l -> `Just_exec
     | 0x202l -> `Service_connect
+    | 0x203l -> `Service_refused
     | 0x210l -> `Trigger_service
     | 0x211l -> `Connection_terminated
     | 0x300l -> `Hello

--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -218,8 +218,8 @@ let listen t handler =
     | `Ok (`Just_exec | `Exec_cmdline as ty, data) ->
         exec t ~ty ~handler data; loop ()
     | `Ok (ty, _) ->
-        Log.info (fun f -> f "unknown qrexec message type received: %ld"
-          (int_of_type ty));
+        Log.info (fun f -> f "unhandled qrexec message type received: %ld (%s)"
+          (int_of_type ty) (string_of_type ty));
         loop ()
     | `Eof ->
         Log.info (fun f -> f "connection closed; ending listen loop");

--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -231,5 +231,5 @@ let connect ~domid () =
   QV.server ~domid ~port:vchan_base_port () >>= fun t ->
   send_hello t >>= fun () ->
   recv_hello t >>= fun version ->
-  Log.info (fun f -> f "client connected, using protocol version %ld" version);
+  Log.info (fun f -> f "client connected on port %s, using protocol version %ld" (Vchan.Port.to_string vchan_base_port) version);
   return t

--- a/lib/rExec.mli
+++ b/lib/rExec.mli
@@ -23,5 +23,16 @@ val listen :  t -> handler -> unit Lwt.t
     and handles each one asynchronously with [handler]. The loop ends if
     the client disconnects. *)
 
+val request_service : t -> target_domain:string -> service_name:string -> handler ->
+  (unit, [`Closed | `Permission_denied | `Msg of string ]) result Lwt.t
+(** [request_service t domain service ident handler] requests
+    via [t] that [domain] start a [service].
+    If the service is requested successfully, `handler` will be invoked
+    with the message flow.
+    [request_service] does not multiplex incoming messages based on a unique
+    identifier, so at most one active channel should be open between two domains
+    at a time.
+*)
+
 val disconnect : t -> unit Lwt.t
 (** Close the underlying vchan. This will cause any listening thread to finish. *)

--- a/lib/rExec.mli
+++ b/lib/rExec.mli
@@ -6,7 +6,13 @@
 
 type t
 
-module Flow : S.FLOW
+module Flow : sig
+  type t
+end
+
+module Stdout : S.FLOW with type t := Flow.t
+module Stdin  : S.FLOW with type t := Flow.t
+module Stderr : S.FLOW with type t := Flow.t
 
 type handler = user:string -> string -> Flow.t -> int Lwt.t
 (** A handler gets a command-line and a two-way connection to the requesting client each time

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -23,23 +23,17 @@ module type FLOW = sig
   type t
 
   val write : t -> Cstruct.t -> unit Lwt.t
-  (** Write to stdout *)
+
+  val read : t -> [`Ok of Cstruct.t | `Eof ] Lwt.t
+
+  val read_line : t -> [`Ok of string | `Eof ] Lwt.t
 
   val writef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
-  (** Write a formatted line to stdout. *)
-
-  val ewrite : t -> Cstruct.t -> unit Lwt.t
-  (** Write to stderr *)
-
-  val ewritef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
-  (** Write a formatted line to stderr. *)
-
-  val read : t -> [`Ok of Cstruct.t | `Eof] Lwt.t
-  (** Read from stdin. *)
-
-  val read_line : t -> [`Ok of string | `Eof] Lwt.t
-  (** Read a complete line from stdin. *)
 end
+
+module Stdout : FLOW
+module Stderr : FLOW
+module Stdin  : FLOW
 
 module type DB = sig
   type t

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -24,16 +24,14 @@ module type FLOW = sig
 
   val write : t -> Cstruct.t -> unit Lwt.t
 
-  val read : t -> [`Ok of Cstruct.t | `Eof ] Lwt.t
+  val read : t -> [ `Ok of Cstruct.t | `Eof ] Lwt.t
 
-  val read_line : t -> [`Ok of string | `Eof ] Lwt.t
+  val read_line : t -> [ `Ok of string | `Eof ] Lwt.t
 
   val writef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
-end
 
-module Stdout : FLOW
-module Stderr : FLOW
-module Stdin  : FLOW
+  val close : t -> int -> [ `Ok of unit | `Eof ] Lwt.t
+end
 
 module type DB = sig
   type t


### PR DESCRIPTION
This change implements a `request_service` function, which lets users request that a service run on their behalf on another VM.  I believe it fixes #23 .

It requires some minor API-breaking changes in the Flow interface, which previously assumed that users would be operating in the client context only.

The signature for `request_service` may be a bit controversial as I don't see result types used elsewhere in the library; I'm happy to rework it to fit in better with other functions here if there's a specific signature that seems more sensible.

@linse and I implemented this to allow a unikernel to request dom0 to run a service on its behalf, and we've tested it only in that context.  The protocol also allows domY to request a service run on domX (where X is not 0), and while this *should* work, we haven't tested it.