### PR TITLE
Change back return type of GUI.listen

### DIFF
--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -28,7 +28,7 @@ val pp_event : Format.formatter -> event -> unit
 val connect : domid:int -> unit -> t Lwt.t
 (** [connect domid ()] connects to the guid in the given [domid] over Vchan. *)
 
-val listen : t -> unit -> t Lwt.t
+val listen : t -> unit -> 'a Lwt.t
 (** [listen ti ()] is an event listener thread. It can be run with Lwt.async
                    and will never return. Events are dispatched to windows
                    created using [create_window].*)


### PR DESCRIPTION
This reverts a change in 2393d8d5b937139fdf705d1defca067c9eb7eadc.

GUI.listen does *not* return normally and we can document it in the type.