### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune"  {build & >= "1.0"}
+  "dune"  {>= "1.0"}
   "mirage-qubes" { >= "0.7.0" }
   "tcpip" { >= "3.5.0" }
   "ipaddr" { >= "3.0.0" }

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune"  {build & >= "1.0"}
+  "dune"  {>= "1.0"}
   "cstruct" { >= "2.2.0" }
   "ppx_cstruct"
   "vchan-xen"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.