### PR TITLE
Travis: Bump OCaml version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
   - PINS="mirage-qubes.dev:. mirage-qubes-ipv4.dev:."
   matrix:
-  - OCAML_VERSION=4.04 PACKAGE=mirage-qubes
-  - OCAML_VERSION=4.04 PACKAGE=mirage-qubes-ipv4
   - OCAML_VERSION=4.05 PACKAGE=mirage-qubes
   - OCAML_VERSION=4.05 PACKAGE=mirage-qubes-ipv4
+  - OCAML_VERSION=4.06 PACKAGE=mirage-qubes
+  - OCAML_VERSION=4.06 PACKAGE=mirage-qubes-ipv4


### PR DESCRIPTION
Latest mirage requires OCaml 4.05.0 or newer.