### PR TITLE
GUI.listen: no need for a unit argument

### DIFF
--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -173,7 +173,7 @@ let connect ~domid () =
   Lwt.return { qv ;
                mvar = [main_window] }
 
-let rec listen t () =
+let rec listen t =
   QV.recv t.qv >>= function
   | `Eof -> failwith "End-of-file from GUId in dom0"
   | `Ok (msg_header , msg_buf) ->
@@ -260,4 +260,4 @@ let rec listen t () =
                  Cstruct.hexdump_pp msg_buf) ;
     UNIT()
   end
-  >>= fun () -> listen t ()
+  >>= fun () -> listen t

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -28,10 +28,10 @@ val pp_event : Format.formatter -> event -> unit
 val connect : domid:int -> unit -> t Lwt.t
 (** [connect domid ()] connects to the guid in the given [domid] over Vchan. *)
 
-val listen : t -> unit -> 'a Lwt.t
-(** [listen ti ()] is an event listener thread. It can be run with Lwt.async
-                   and will never return. Events are dispatched to windows
-                   created using [create_window].*)
+val listen : t -> 'a Lwt.t
+(** [listen ti] is an event listener thread. It can be run with Lwt.async
+                and will never return. Events are dispatched to windows
+                created using [create_window].*)
 
 val set_title : window -> string -> unit S.or_eof Lwt.t
 val int32_of_window : window -> int32

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,3 +1,0 @@
-#!/usr/bin/env ocaml
-#use "topfind"
-#require "topkg-jbuilder.auto"


### PR DESCRIPTION
it is not clear why this was changed in https://github.com/mirage/mirage-qubes/commit/2393d8d5b937139fdf705d1defca067c9eb7eadc //cc @cfcs -- was there a good reason to introduce the `unit` argument?

I know this has been released since then (i.e. this PR breaks the API again), but that's fine. (see as well @reynir comment at https://github.com/mirage/mirage-qubes/commit/2393d8d5b937139fdf705d1defca067c9eb7eadc#r34791187) -- and with lwt 5.0.0 being released now (where `Lwt.async` requires `unit -> unit Lwt.t`), should the return type of `val listen` ("it never returns") be `unit Lwt.t` instead?