### PR TITLE
Qubesdb with commit

### DIFF
--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -84,7 +84,7 @@ let rm t path =
       ) else true
     )
     |> update t ;
-    let path_without_slash = String.sub path 0 (len - 2) in
+    let path_without_slash = String.sub path 0 (len - 1) in
     t.committed_store <- KeyMap.remove path_without_slash t.committed_store;
   ) else (
     if not (KeyMap.mem path t.store) then

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -23,6 +23,7 @@ type t = {
   notify : unit Lwt_condition.t;
   commit : string Lwt_condition.t;
   mutable store : string KeyMap.t;
+  mutable committed_store : string KeyMap.t KeyMap.t;
 }
 
 let update t bindings =
@@ -50,6 +51,9 @@ let recv t =
   let path = String.sub path 0 (String.index path '\x00') in
   Lwt.return (ty, path, Cstruct.to_string data)
 
+let values_for_key store key =
+  KeyMap.filter (fun k _ -> starts_with k (key ^ "/")) store
+
 let full_db_sync t =
   send t.vchan QDB_CMD_MULTIREAD >>!= fun () ->
   let rec loop () =
@@ -62,6 +66,10 @@ let full_db_sync t =
     | ty, _, _ -> fail (error "Unexpected QubesDB message: %s" (qdb_msg_to_string ty)) in
   loop () >>= fun `Done ->
   Lwt_condition.broadcast t.notify ();  (* (probably not needed) *)
+  KeyMap.iter (fun k v ->
+    if v = "" then
+      t.committed_store <- KeyMap.add k (values_for_key t.store k) t.committed_store)
+    t.store;
   return ()
 
 let rm t path =
@@ -75,7 +83,9 @@ let rm t path =
         false
       ) else true
     )
-    |> update t
+    |> update t ;
+    let path_without_slash = String.sub path 0 (len - 2) in
+    t.committed_store <- KeyMap.remove path_without_slash t.committed_store;
   ) else (
     if not (KeyMap.mem path t.store) then
       Log.err (fun f -> f "%S not found (fatal database de-synchronization)" path);
@@ -93,7 +103,10 @@ let listen t =
         Log.info (fun f -> f "got update: %S = %S" path value);
         t.store |> KeyMap.add path value |> update t;
         ack path >>= fun () ->
-        if value = "" then Lwt_condition.broadcast t.commit path;
+        if value = "" then (
+          t.committed_store <- KeyMap.add path (values_for_key t.store path) t.committed_store;
+          Lwt_condition.broadcast t.commit path
+        );
         loop ()
     | QDB_RESP_OK, path, _ ->
         Log.debug (fun f -> f "OK %S" path);
@@ -113,7 +126,7 @@ let connect ~domid () =
   Log.info (fun f -> f "connecting to server...");
   QV.client ~domid ~port:qubesdb_vchan_port () >>= fun vchan ->
   Log.info (fun f -> f "connected");
-  let t = {vchan; store = KeyMap.empty; notify = Lwt_condition.create (); commit = Lwt_condition.create ()} in
+  let t = {vchan; store = KeyMap.empty; committed_store = KeyMap.empty; notify = Lwt_condition.create (); commit = Lwt_condition.create ()} in
   full_db_sync t >>= fun () ->
   Lwt.async (fun () -> listen t);
   Lwt.return t
@@ -137,13 +150,50 @@ let rec after t prev =
     after t prev
   ) else return current
 
-let values t key =
-  KeyMap.filter (fun k _ -> starts_with k (key ^ "/")) t.store
+let find_committed_key t key =
+  match KeyMap.find_opt key t.committed_store with
+  | None -> KeyMap.empty
+  | Some map -> map
 
-let rec got_new_commit t key =
-  Lwt_condition.wait t.commit >>= fun key' ->
-  if String.equal key key' then
-    let values = values t key in
-    return values
-  else
-    got_new_commit t key
+let rec got_new_commit t key prev =
+  let values = find_committed_key t key in
+  if KeyMap.equal (=) prev values then (
+    Lwt_condition.wait t.commit >>= fun key' ->
+    if String.equal key key' then
+      let values = find_committed_key t key in
+      return values
+    else
+      got_new_commit t key prev
+  ) else return values
+
+(* Three sequences of events with commit can happen
+1 - got_new_commit is called first, and waits for the commit
+client: got_new_commit "/foo" empty -> empty = t.committed_store -> wait for condition
+QubesDB: updates fuer /foo/bar
+QubesDB: updates fuer /foo/bar2
+QubesDB: commit fuer foo -> Lwt_conditioan.broadcast wakes up client
+client: returns from got_new_commit
+
+2 - got_new_commit while updates are in progress and not committed yet:
+QubesDB: updates fuer /foo/bar
+client: got_new_commit "/foo" empty => empty = t.committed_store -> wait for condition
+QubesDB: updates fuer /foo/bar2
+QubesDB: commit fuer foo -> t.committed_store <- t.store --> Lwt_condition.broadcast wakes up client
+client: return from got_new_commit
+
+3 - got_new_commit after commit:
+QubesDB: updates fuer /foo/bar
+QubesDB: updates fuer /foo/bar2
+QubesDB: commit fuer foo -> t.committed_store <- t.store
+client: got_new_commit "/foo" empty => empty <> t.committed_store
+client: return from got_new_commit
+
+4 - interleaving commits on qubesDB for different keys
+QubesDB: updates for /foo/bar
+QubesDB: updates for /bar/foo
+QubesDB: commit for foo
+client: got_new_commit "bar" empty
+QubesDB: updates for /bar/foobar
+QubesDB: commit for bar
+client: return from got_new_commit
+*)

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -137,12 +137,13 @@ let rec after t prev =
     after t prev
   ) else return current
 
+let values t key =
+  KeyMap.filter (fun k _ -> starts_with k (key ^ "/")) t.store
+
 let rec got_new_commit t key =
   Lwt_condition.wait t.commit >>= fun key' ->
   if String.equal key key' then
-    let values =
-      KeyMap.filter (fun k _ -> starts_with k (key ^ "/")) t.store
-    in
+    let values = values t key in
     return values
   else
     got_new_commit t key

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -46,10 +46,6 @@ module type DB = sig
 
   module KeyMap : Map.S with type key = string
 
-  val values : t -> string -> string KeyMap.t
-  (** [values t key] is the database that contains all values whose prefix
-     is [key]. *)
-
   val read :  t -> string -> string option
   (** [read t key] is the last known value of [key]. *)
 
@@ -63,8 +59,9 @@ module type DB = sig
   (** [after prev] waits until the current bindings are different to [prev]
       and then returns the new bindings. *)
 
-  val got_new_commit : t -> string -> string KeyMap.t Lwt.t
-  (** [got_new_commit t key] waits until a new commit (empty write) has been
-      written to [key] into the qubesDB [t]. Returns the entries starting with
+  val got_new_commit : t -> string -> string KeyMap.t -> string KeyMap.t Lwt.t
+  (** [got_new_commit t key prev] either waits until a new commit (empty write)
+      has been written to [key] into the qubesDB [t], or the entries starting
+      with [key] are different from [prev]. Returns the entries starting with
       [key]. *)
 end

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -58,4 +58,9 @@ module type DB = sig
   val after : t -> string KeyMap.t -> string KeyMap.t Lwt.t
   (** [after prev] waits until the current bindings are different to [prev]
       and then returns the new bindings. *)
+
+  val got_new_commit : t -> string -> string KeyMap.t Lwt.t
+  (** [got_new_commit t key] waits until a new commit (empty write) has been
+      written to [key] into the qubesDB [t]. Returns the entries starting with
+      [key]. *)
 end

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -46,6 +46,10 @@ module type DB = sig
 
   module KeyMap : Map.S with type key = string
 
+  val values : t -> string -> string KeyMap.t
+  (** [values t key] is the database that contains all values whose prefix
+     is [key]. *)
+
   val read :  t -> string -> string option
   (** [read t key] is the last known value of [key]. *)
 


### PR DESCRIPTION
Hello,

we extended the Qubes.DB module to provide two new functions:
- got_new_commit : t -> string -> map Lwt.t
- values : t -> string -> map Lwt.t

The first resolves once the provided `key` is written to with an empty string (this is used in Qubes to signal a commit). It provides a partial map, where only keys with `key` as prefix are contained. The function `values` does the latter.

The reason for these functions is to properly react to QubesDB updates (in our case, firewall updates), and not using a QubesDB where firewall rules are only partially written. This cannot be implemented with just the provided `after`.