### PR TITLE
Remove unused xen-gnt dependency

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,6 @@
 (library
  (name qubes)
  (public_name mirage-qubes)
- (libraries cstruct vchan-xen xen-evtchn xen-gnt mirage-xen lwt
-   logs)
+ (libraries cstruct vchan-xen mirage-xen lwt logs)
  (preprocess
   (pps ppx_cstruct)))

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -17,8 +17,6 @@ depends: [
   "cstruct" { >= "2.2.0" }
   "ppx_cstruct"
   "vchan-xen" { >= "5.0.0" }
-  "xen-evtchn"
-  "xen-gnt"
   "mirage-xen" { >= "5.0.0" }
   "lwt"
   "logs" { >= "0.5.0" }


### PR DESCRIPTION
`xen-gnt`'s functionality now comes directly from `mirage-xen`.
Also, remove `xen-evtchn`, which we don't use directly.

These were added in cae1fd1e912535373db96f682cd703b773314b4c to force vchan to build for Xen, back when it used depopts.