### PR TITLE
move starts_with from Utils to DB -- where it is used

### DIFF
--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -8,7 +8,7 @@ let (>>!=) x f =
   x >>= function
   | `Ok y -> f y
   | `Eof -> Lwt.fail_with "qubesdb-agent: end-of-file from QubesDB!"
-  | `Error (`Unknown msg) -> Lwt.fail (Fmt.failwith "qubesdb-agent: %s" msg)
+  | `Error (`Unknown msg) -> Fmt.failwith "qubesdb-agent: %s" msg
 
 let starts_with str prefix =
   let ls = String.length str in
@@ -72,7 +72,7 @@ let full_db_sync t =
         Log.debug (fun f -> f "%S = %S" path data);
         t.store <- t.store |> KeyMap.add path data;
         loop ()
-    | ty, _, _ -> Lwt.fail (Fmt.failwith "Unexpected QubesDB message: %s" (qdb_msg_to_string ty)) in
+    | ty, _, _ -> Fmt.failwith "Unexpected QubesDB message: %s" (qdb_msg_to_string ty) in
   loop () >>= fun `Done ->
   Lwt_condition.broadcast t.notify ();  (* (probably not needed) *)
   KeyMap.iter (fun k v ->

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -11,6 +11,16 @@ let (>>!=) x f =
   | `Eof -> fail (Failure "qubesdb-agent: end-of-file from QubesDB!")
   | `Error (`Unknown msg) -> fail (error "qubesdb-agent: %s" msg)
 
+let starts_with str prefix =
+  let ls = String.length str in
+  let lp = String.length prefix in
+  if lp > ls then false else
+    let rec loop i =
+      if i = lp then true
+      else if str.[i] <> prefix.[i] then false
+      else loop (i + 1)
+    in loop 0
+
 module QV = Msg_chan.Make(Framing)
 
 let src = Logs.Src.create "qubes.db" ~doc:"QubesDB agent"

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -1,15 +1,14 @@
 (* Copyright (C) 2015, Thomas Leonard
    See the README file for details. *)
 
-open Utils
 open Lwt.Infix
 open Formats.QubesDB
 
 let (>>!=) x f =
   x >>= function
   | `Ok y -> f y
-  | `Eof -> fail (Failure "qubesdb-agent: end-of-file from QubesDB!")
-  | `Error (`Unknown msg) -> fail (error "qubesdb-agent: %s" msg)
+  | `Eof -> Lwt.fail_with "qubesdb-agent: end-of-file from QubesDB!"
+  | `Error (`Unknown msg) -> Lwt.fail (Fmt.failwith "qubesdb-agent: %s" msg)
 
 let starts_with str prefix =
   let ls = String.length str in
@@ -55,7 +54,7 @@ let recv t =
   let ty =
     let ty = get_msg_header_ty hdr in
     match int_to_qdb_msg ty with
-    | None -> raise (error "Invalid message type %d" ty)
+    | None -> Fmt.failwith "Invalid message type %d" ty
     | Some ty -> ty in
   let path = Cstruct.to_string (get_msg_header_path hdr) in
   let path = String.sub path 0 (String.index path '\x00') in
@@ -68,19 +67,19 @@ let full_db_sync t =
   send t.vchan QDB_CMD_MULTIREAD >>!= fun () ->
   let rec loop () =
     recv t.vchan >>= function
-    | QDB_RESP_MULTIREAD, "", _ -> return `Done
+    | QDB_RESP_MULTIREAD, "", _ -> Lwt.return `Done
     | QDB_RESP_MULTIREAD, path, data ->
         Log.debug (fun f -> f "%S = %S" path data);
         t.store <- t.store |> KeyMap.add path data;
         loop ()
-    | ty, _, _ -> fail (error "Unexpected QubesDB message: %s" (qdb_msg_to_string ty)) in
+    | ty, _, _ -> Lwt.fail (Fmt.failwith "Unexpected QubesDB message: %s" (qdb_msg_to_string ty)) in
   loop () >>= fun `Done ->
   Lwt_condition.broadcast t.notify ();  (* (probably not needed) *)
   KeyMap.iter (fun k v ->
     if v = "" then
       t.committed_store <- KeyMap.add k (values_for_key t.store k) t.committed_store)
     t.store;
-  return ()
+  Lwt.return_unit
 
 let rm t path =
   let len = String.length path in
@@ -106,7 +105,7 @@ let listen t =
   let rec loop () =
     let ack path =
       send t.vchan ~path QDB_RESP_OK >|= function
-      | `Eof -> raise (error "End-of-file sending OK")
+      | `Eof -> failwith "End-of-file sending OK"
       | `Ok () -> () in
     recv t.vchan >>= function
     | QDB_CMD_WRITE, path, value ->
@@ -129,7 +128,7 @@ let listen t =
         Log.err (fun f -> f "Error from peer (for %S)" path);
         loop ()
     | ty, _, _ ->
-        fail (error "Unexpected QubesDB message: %s" (qdb_msg_to_string ty)) in
+        Fmt.failwith "Unexpected QubesDB message: %s" (qdb_msg_to_string ty) in
   loop () >|= fun `Done -> ()
 
 let connect ~domid () =
@@ -149,7 +148,7 @@ let read t key =
 
 let write t key value =
   send t.vchan QDB_CMD_WRITE ~path:key ~data:value >>!= fun () ->
-  return ()
+  Lwt.return_unit
 
 let bindings t = t.store
 
@@ -158,7 +157,7 @@ let rec after t prev =
   if KeyMap.equal (=) prev current then (
     Lwt_condition.wait t.notify >>= fun () ->
     after t prev
-  ) else return current
+  ) else Lwt.return current
 
 let find_committed_key t key =
   match KeyMap.find_opt key t.committed_store with
@@ -171,10 +170,10 @@ let rec got_new_commit t key prev =
     Lwt_condition.wait t.commit >>= fun key' ->
     if String.equal key key' then
       let values = find_committed_key t key in
-      return values
+      Lwt.return values
     else
       got_new_commit t key prev
-  ) else return values
+  ) else Lwt.return values
 
 (* Three sequences of events with commit can happen
 1 - got_new_commit is called first, and waits for the commit

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -1,8 +1,6 @@
 (** The Qubes wire protocol details. *)
 (** for more details, see qubes-gui-common/include/qubes-gui-protocol.h *)
 
-open Utils
-
 module type FRAMING = sig
   val header_size : int
   val body_size_from_header : Cstruct.t -> int
@@ -594,8 +592,7 @@ module QubesDB = struct
   let make_msg_header ~ty ~path ~data_len =
     let msg = Cstruct.create sizeof_msg_header in
     set_msg_header_ty msg (qdb_msg_to_int ty);
-    set_fixed_string (get_msg_header_path msg) path;
-    Cstruct.memset (get_msg_header_padding msg) 0;
+    Cstruct.blit_from_string path 0 (get_msg_header_path msg) 0 (String.length path);
     set_msg_header_data_len msg (Int32.of_int data_len);
     msg
 

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -3,7 +3,6 @@
 
 open Lwt.Infix
 open Formats.GUI
-open Utils
 
 module QV = Msg_chan.Make(Framing)
 
@@ -156,10 +155,10 @@ let connect ~domid () =
   let version = Cstruct.create sizeof_gui_protocol_version in
   set_gui_protocol_version_version version qubes_gui_protocol_version_linux;
   QV.send qv [version] >>= function
-  | `Eof -> Lwt.fail (error "End-of-file sending protocol version")
+  | `Eof -> Lwt.fail (Utils.error "End-of-file sending protocol version")
   | `Ok () ->
   QV.recv_fixed qv sizeof_xconf >>= function
-  | `Eof -> Lwt.fail (error "End-of-file getting X configuration")
+  | `Eof -> Lwt.fail (Utils.error "End-of-file getting X configuration")
   | `Ok conf ->
   let screen_w = get_xconf_w conf in
   let screen_h = get_xconf_h conf in

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -181,7 +181,7 @@ let rec listen t () =
     match List.find (fun t -> t.no = window) t.mvar with
     | w -> Lwt_mvar.put w.mvar event
     | exception _ -> Log.warn (fun m -> m "No such window %ld" window);
-                     Lwt.return ()
+                     Lwt.return_unit
   in
   let msg_len = get_msg_header_untrusted_len msg_header |> Int32.to_int in
   send_to_window

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -155,10 +155,10 @@ let connect ~domid () =
   let version = Cstruct.create sizeof_gui_protocol_version in
   set_gui_protocol_version_version version qubes_gui_protocol_version_linux;
   QV.send qv [version] >>= function
-  | `Eof -> Lwt.fail (Utils.error "End-of-file sending protocol version")
+  | `Eof -> Lwt.fail_with "End-of-file sending protocol version"
   | `Ok () ->
   QV.recv_fixed qv sizeof_xconf >>= function
-  | `Eof -> Lwt.fail (Utils.error "End-of-file getting X configuration")
+  | `Eof -> Lwt.fail_with "End-of-file getting X configuration"
   | `Ok conf ->
   let screen_w = get_xconf_w conf in
   let screen_h = get_xconf_h conf in

--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -83,7 +83,7 @@ module Flow = struct
     recv flow.dstream >>!= function
     | `Data_stdin, empty when Cstruct.len empty = 0 -> Lwt.return `Eof
     | `Data_stdin, data -> Lwt.return (`Ok data)
-    | ty, _ -> Lwt.fail (Fmt.failwith "Unknown message type %ld received" (int_of_type ty))
+    | ty, _ -> Fmt.failwith "Unknown message type %ld received" (int_of_type ty)
 
   let read flow =
     if Cstruct.len flow.stdin_buf > 0 then (
@@ -200,7 +200,7 @@ let recv_hello t =
   recv t >>= function
   | `Eof -> Lwt.fail_with "End-of-file waiting for msg_hello"
   | `Ok (`Hello, resp) -> Lwt.return (get_peer_info_version resp)
-  | `Ok (ty, _) -> Lwt.fail (Fmt.failwith "Expected msg_hello, got %ld" (int_of_type ty))
+  | `Ok (ty, _) -> Fmt.failwith "Expected msg_hello, got %ld" (int_of_type ty)
 
 let try_close flow return_code =
   Flow.close flow return_code >|= function
@@ -214,7 +214,7 @@ let with_flow ~ty ~domid ~port fn =
       Lwt.catch
         (fun () ->
           recv_hello client >>= function
-          | version when version < 2l -> Lwt.fail (Fmt.failwith "Unsupported qrexec version %ld" version)
+          | version when version < 2l -> Fmt.failwith "Unsupported qrexec version %ld" version
           | version ->
             Log.info (fun f -> f "client connected, \
                                   other end wants to use protocol version %lu, \
@@ -251,7 +251,7 @@ let parse_cmdline cmd =
   else (
     let cmd = String.sub cmd 0 (String.length cmd - 1) in
     match cmd |> split ':' with
-    | None -> Lwt.fail (Fmt.failwith "Missing ':' in %S" cmd)
+    | None -> Fmt.failwith "Missing ':' in %S" cmd
     | Some (user, cmd) -> Lwt.return (user, cmd)
   )
 
@@ -376,7 +376,7 @@ let connect ~domid () =
   let t = { t; clients = Hashtbl.create 4; counter = 0; } in
   send_hello t.t >>= fun () ->
   recv_hello t.t >>= function
-  | version when version < 2l -> Lwt.fail (Fmt.failwith "Unsupported qrexec version %ld" version)
+  | version when version < 2l -> Fmt.failwith "Unsupported qrexec version %ld" version
   | version ->
     Log.info (fun f -> f "client connected, \
                           other end wants to use protocol version %lu, \

--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -3,7 +3,6 @@
 
 open Lwt.Infix
 open Formats.Qrexec
-open Utils
 
 module QV = Msg_chan.Make(Framing)
 
@@ -20,9 +19,9 @@ let split chr s =
     None
 
 let or_fail = function
-  | `Ok y -> return y
-  | `Error (`Unknown msg) -> fail (Failure msg)
-  | `Eof -> fail End_of_file
+  | `Ok y -> Lwt.return y
+  | `Error (`Unknown msg) -> Lwt.fail_with msg
+  | `Eof -> Lwt.fail End_of_file
 
 let vchan_base_port =
   match Vchan.Port.of_string "512" with
@@ -40,14 +39,14 @@ let rec send t ~ty data =
   if Cstruct.len data' = 0
   then QV.send t [hdr; data]
   else QV.send t [hdr; data] >>= function
-    | `Eof -> return `Eof
+    | `Eof -> Lwt.return `Eof
     | `Ok () ->
       send t ~ty data'
 
 let recv t =
   QV.recv t >>!= fun (hdr, data) ->
   let ty = get_msg_header_ty hdr |> type_of_int in
-  return (`Ok (ty, data))
+  Lwt.return (`Ok (ty, data))
 
 module Flow = struct
   type t = {
@@ -60,12 +59,12 @@ module Flow = struct
 
   let push ~stream flow buf =
     match flow.ty with
-    | `Just_exec -> return ()
+    | `Just_exec -> Lwt.return_unit
     | `Exec_cmdline ->
     if Cstruct.len buf > 0 then
       send flow.dstream ~ty:stream buf >>= or_fail
     else
-      return ()
+      Lwt.return_unit
 
   let pushf ~stream flow fmt =
     fmt |> Printf.ksprintf @@ fun s ->
@@ -79,18 +78,18 @@ module Flow = struct
 
   let read_raw flow =
     match flow.ty with
-    | `Just_exec -> return `Eof
+    | `Just_exec -> Lwt.return `Eof
     | `Exec_cmdline ->
     recv flow.dstream >>!= function
-    | `Data_stdin, empty when Cstruct.len empty = 0 -> return `Eof
-    | `Data_stdin, data -> return (`Ok data)
-    | ty, _ -> fail (error "Unknown message type %ld received" (int_of_type ty))
+    | `Data_stdin, empty when Cstruct.len empty = 0 -> Lwt.return `Eof
+    | `Data_stdin, data -> Lwt.return (`Ok data)
+    | ty, _ -> Lwt.fail (Fmt.failwith "Unknown message type %ld received" (int_of_type ty))
 
   let read flow =
     if Cstruct.len flow.stdin_buf > 0 then (
       let retval = flow.stdin_buf in
       flow.stdin_buf <- Cstruct.create 0;
-      return (`Ok retval)
+      Lwt.return (`Ok retval)
     ) else read_raw flow
 
   let rec read_line flow =
@@ -102,7 +101,7 @@ module Flow = struct
     | Some i ->
         let retval = String.sub buf 0 i in
         flow.stdin_buf <- Cstruct.shift flow.stdin_buf (i + 1);
-        return (`Ok retval)
+        Lwt.return (`Ok retval)
     | None ->
         read_raw flow >>!= fun buf ->
         flow.stdin_buf <- Cstruct.append flow.stdin_buf buf;
@@ -115,7 +114,7 @@ module Flow = struct
       (fun () ->
         send flow.dstream ~ty:`Data_stdout (Cstruct.create 0) >>!= fun () ->
         send flow.dstream ~ty:`Data_exit_code msg >>!= fun () ->
-        return (`Ok ())
+        Lwt.return (`Ok ())
       )
       (fun () -> QV.disconnect flow.dstream)
 end
@@ -194,14 +193,14 @@ let send_hello t =
   let hello = Cstruct.create sizeof_peer_info in
   set_peer_info_version hello 2l;
   send t ~ty:`Hello hello >>= function
-  | `Eof -> fail (error "End-of-file sending msg_hello")
-  | `Ok () -> return ()
+  | `Eof -> Lwt.fail_with "End-of-file sending msg_hello"
+  | `Ok () -> Lwt.return_unit
 
 let recv_hello t =
   recv t >>= function
-  | `Eof -> fail (error "End-of-file waiting for msg_hello")
-  | `Ok (`Hello, resp) -> return (get_peer_info_version resp)
-  | `Ok (ty, _) -> fail (error "Expected msg_hello, got %ld" (int_of_type ty))
+  | `Eof -> Lwt.fail_with "End-of-file waiting for msg_hello"
+  | `Ok (`Hello, resp) -> Lwt.return (get_peer_info_version resp)
+  | `Ok (ty, _) -> Lwt.fail (Fmt.failwith "Expected msg_hello, got %ld" (int_of_type ty))
 
 let try_close flow return_code =
   Flow.close flow return_code >|= function
@@ -215,7 +214,7 @@ let with_flow ~ty ~domid ~port fn =
       Lwt.catch
         (fun () ->
           recv_hello client >>= function
-          | version when version < 2l -> fail (error "Unsupported qrexec version %ld" version)
+          | version when version < 2l -> Lwt.fail (Fmt.failwith "Unsupported qrexec version %ld" version)
           | version ->
             Log.info (fun f -> f "client connected, \
                                   other end wants to use protocol version %lu, \
@@ -223,7 +222,7 @@ let with_flow ~ty ~domid ~port fn =
             send_hello client >|= fun () ->
             Flow.create ~ty client
         )
-        (fun ex -> QV.disconnect client >>= fun () -> fail ex)
+        (fun ex -> QV.disconnect client >>= fun () -> Lwt.fail ex)
     )
     (fun flow ->
       Lwt.try_bind
@@ -237,7 +236,7 @@ let with_flow ~ty ~domid ~port fn =
     (fun ex ->
       Log.warn (fun f -> f "Error setting up vchan (domain %d, port %s): %s"
         domid (Vchan.Port.to_string port) (Printexc.to_string ex));
-      return ()
+      Lwt.return_unit
     )
 
 let port_of_int i =
@@ -248,12 +247,12 @@ let port_of_int i =
 let parse_cmdline cmd =
   let cmd = Cstruct.to_string cmd in
   if cmd.[String.length cmd - 1] <> '\x00' then
-    fail (error "Command not null-terminated")
+    Lwt.fail_with "Command not null-terminated"
   else (
     let cmd = String.sub cmd 0 (String.length cmd - 1) in
     match cmd |> split ':' with
-    | None -> fail (error "Missing ':' in %S" cmd)
-    | Some (user, cmd) -> return (user, cmd)
+    | None -> Lwt.fail (Fmt.failwith "Missing ':' in %S" cmd)
+    | Some (user, cmd) -> Lwt.return (user, cmd)
   )
 
 let exec t ~ty ~handler msg =
@@ -268,7 +267,7 @@ let exec t ~ty ~handler msg =
           parse_cmdline cmdline >>= fun (user, cmd) ->
           handler ~user cmd flow >>= fun return_code ->
           Log.debug (fun f -> f "%S returned exit status %d" cmd return_code);
-          return return_code
+          Lwt.return return_code
         )
       )
       (fun () ->
@@ -337,7 +336,7 @@ let listen t handler =
         Log.info (fun f -> f "dom0 rexec vchan connection closed; ending listen loop");
         (* Clean up client callbacks that will no longer be called *)
         Hashtbl.reset t.clients;
-        return `Done in
+        Lwt.return `Done in
   loop () >|= fun `Done -> ()
 
 let qrexec t ~vm ~service client =
@@ -377,9 +376,9 @@ let connect ~domid () =
   let t = { t; clients = Hashtbl.create 4; counter = 0; } in
   send_hello t.t >>= fun () ->
   recv_hello t.t >>= function
-  | version when version < 2l -> fail (error "Unsupported qrexec version %ld" version)
+  | version when version < 2l -> Lwt.fail (Fmt.failwith "Unsupported qrexec version %ld" version)
   | version ->
     Log.info (fun f -> f "client connected, \
                           other end wants to use protocol version %lu, \
                           continuing with version 2" version);
-    return t
+    Lwt.return t

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -1,7 +1,0 @@
-let error fmt =
-  let err s = Failure s in
-  Printf.ksprintf err fmt
-
-let return = Lwt.return
-let fail = Lwt.fail
-

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -5,18 +5,3 @@ let error fmt =
 let return = Lwt.return
 let fail = Lwt.fail
 
-(* Copy str to the start of buffer and fill the rest with zeros *)
-let set_fixed_string buffer str =
-  let len = String.length str in
-  Cstruct.blit_from_string str 0 buffer 0 len;
-  Cstruct.memset (Cstruct.shift buffer len) 0
-
-let starts_with str prefix =
-  let ls = String.length str in
-  let lp = String.length prefix in
-  if lp > ls then false else
-    let rec loop i =
-      if i = lp then true
-      else if str.[i] <> prefix.[i] then false
-      else loop (i + 1)
-    in loop 0


### PR DESCRIPTION
simplify and move set_fixed_string into single user in Formats

shrink the Utils module, avoid opening it in Formats and GUI (where it is not
used much).

this is on the road to address #12