### PR TITLE
Remove no longer relevant comment

### DIFF
--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -30,7 +30,6 @@ module Qrexec = struct
 
   [%%cstruct
       type exit_status = {
-        (* XXX: size of message depends on native int size?? *)
         return_code : uint32_t;
       } [@@little_endian]
   ]


### PR DESCRIPTION
The exit code is now specified to be uint32_t in qrexec.h.