### PR TITLE
Remove internal Cstruct.t

### DIFF
--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -45,8 +45,8 @@ let qubesdb_vchan_port =
   | Ok port -> port
 
 let send t ?(path="") ?(data="") ty =
-  let data = Cstruct.of_string data in
-  let hdr = make_msg_header ~ty ~path ~data_len:(Cstruct.length data) in
+  let data = Bytes.of_string data in
+  let hdr = make_msg_header ~ty ~path ~data_len:(Bytes.length data) in
   QV.send t [hdr; data]
 
 let recv t =
@@ -56,9 +56,9 @@ let recv t =
     match int_to_qdb_msg ty with
     | None -> Fmt.failwith "Invalid message type %d" ty
     | Some ty -> ty in
-  let path = Cstruct.to_string (get_msg_header_path hdr) in
+  let path = Bytes.to_string (get_msg_header_path hdr) in
   let path = String.sub path 0 (String.index path '\x00') in
-  Lwt.return (ty, path, Cstruct.to_string data)
+  Lwt.return (ty, path, Bytes.to_string data)
 
 let values_for_key store key =
   KeyMap.filter (fun k _ -> starts_with k (key ^ "/")) store

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -66,7 +66,9 @@ let values_for_key store key =
 let full_db_sync t =
   send t.vchan QDB_CMD_MULTIREAD >>!= fun () ->
   let rec loop () =
-    recv t.vchan >>= function
+    recv t.vchan >>= function (*fun (ty, path, data) ->
+    Printf.printf "got path %s with %s\n" path  (qdb_msg_to_string ty) ;
+    match (ty, path, data) with*)
     | QDB_RESP_MULTIREAD, "", _ -> Lwt.return `Done
     | QDB_RESP_MULTIREAD, path, data ->
         Log.debug (fun f -> f "%S = %S" path data);

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -56,9 +56,9 @@ let recv t =
     match int_to_qdb_msg ty with
     | None -> Fmt.failwith "Invalid message type %d" ty
     | Some ty -> ty in
-  let path = Bytes.to_string (get_msg_header_path hdr) in
-  let path = String.sub path 0 (String.index path '\x00') in
-  Lwt.return (ty, path, Bytes.to_string data)
+  let path = get_msg_header_path hdr in
+  let path = Bytes.sub path 0 (Bytes.index path '\x00') in
+  Lwt.return (ty, Bytes.to_string path, Bytes.to_string data)
 
 let values_for_key store key =
   KeyMap.filter (fun k _ -> starts_with k (key ^ "/")) store

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -66,9 +66,7 @@ let values_for_key store key =
 let full_db_sync t =
   send t.vchan QDB_CMD_MULTIREAD >>!= fun () ->
   let rec loop () =
-    recv t.vchan >>= function (*fun (ty, path, data) ->
-    Printf.printf "got path %s with %s\n" path  (qdb_msg_to_string ty) ;
-    match (ty, path, data) with*)
+    recv t.vchan >>= function
     | QDB_RESP_MULTIREAD, "", _ -> Lwt.return `Done
     | QDB_RESP_MULTIREAD, path, data ->
         Log.debug (fun f -> f "%S = %S" path data);

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -45,8 +45,7 @@ let qubesdb_vchan_port =
   | Ok port -> port
 
 let send t ?(path="") ?(data="") ty =
-  let data = Bytes.of_string data in
-  let hdr = make_msg_header ~ty ~path ~data_len:(Bytes.length data) in
+  let hdr = make_msg_header ~ty ~path ~data_len:(String.length data) in
   QV.send t [hdr; data]
 
 let recv t =
@@ -57,8 +56,8 @@ let recv t =
     | None -> Fmt.failwith "Invalid message type %d" ty
     | Some ty -> ty in
   let path = get_msg_header_path hdr in
-  let path = Bytes.sub path 0 (Bytes.index path '\x00') in
-  Lwt.return (ty, Bytes.to_string path, Bytes.to_string data)
+  let path = String.sub path 0 (String.index path '\x00') in
+  Lwt.return (ty, path, data)
 
 let values_for_key store key =
   KeyMap.filter (fun k _ -> starts_with k (key ^ "/")) store

--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -7,7 +7,7 @@ open Formats.QubesDB
 let (>>!=) x f =
   x >>= function
   | `Ok y -> f y
-  | `Eof -> Lwt.fail_with "qubesdb-agent: end-of-file from QubesDB!"
+  | `Eof -> failwith "qubesdb-agent: end-of-file from QubesDB!"
   | `Error (`Unknown msg) -> Fmt.failwith "qubesdb-agent: %s" msg
 
 let starts_with str prefix =

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name qubes)
  (public_name mirage-qubes)
- (libraries cstruct vchan-xen mirage-xen lwt logs)
+ (libraries cstruct ohex vchan-xen mirage-xen lwt logs)
  (preprocess
   (pps ppx_cstruct)))

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -50,9 +50,9 @@ module Qrexec = struct
       let get_trigger_service_params_service_name h = Bytes.sub h 0 64
       let set_trigger_service_params_service_name v ofs h = Bytes.blit_string v 0 h ofs 64
       let get_trigger_service_params_target_domain h = Bytes.sub h 64 32
-      let set_trigger_service_params_target_domain v ofs h = Bytes.blit_string v 0 h ofs 32
+      let set_trigger_service_params_target_domain v ofs h = Bytes.blit_string v 0 h (64+ofs) 32
       let get_trigger_service_params_request_id h = Bytes.sub h 96 32
-      let set_trigger_service_params_request_id v ofs h = Bytes.blit_string v 0 h ofs 32
+      let set_trigger_service_params_request_id v ofs h = Bytes.blit_string v 0 h (96+ofs) 32
       let sizeof_trigger_service_params = 64+32+32
 
       type trigger_service_params3 = {
@@ -63,7 +63,7 @@ module Qrexec = struct
       let get_trigger_service_params3_target_domain h = Bytes.sub h 0 64
       let set_trigger_service_params3_target_domain v ofs h = Bytes.blit_string v 0 h ofs 64
       let get_trigger_service_params3_request_id h = Bytes.sub h 64 32
-      let set_trigger_service_params3_request_id v ofs h = Bytes.blit_string v 0 h ofs 32
+      let set_trigger_service_params3_request_id v ofs h = Bytes.blit_string v 0 h (64+ofs) 32
       let sizeof_trigger_service_params3 = 64+32
     
   type msg_type =
@@ -452,8 +452,8 @@ module GUI = struct
       type msg_execute = {
         cmd: Bytes.t; (* uint8_t [@len 255]; *)
       }
-      let get_msg_execute_cmd h = h
-      let set_msg_execute_cmd h v = Bytes.blit v 0 h 0 255
+      (* let get_msg_execute_cmd h = h *)
+      (* let set_msg_execute_cmd h v = Bytes.blit v 0 h 0 255 *)
       let sizeof_msg_execute = 255
 
   (** Dom0 -> VM: Xorg conf *)
@@ -482,8 +482,8 @@ module GUI = struct
       type msg_wmname = {
         data : Bytes.t (*uint8_t  [@len 128];*) (* title of the window *)
       }
-      let get_msg_wmname_data h = h
-      let set_msg_wmname_data h v = Bytes.blit v 0 h 0 128
+      (* let get_msg_wmname_data h = h *)
+      (* let set_msg_wmname_data h v = Bytes.blit v 0 h 0 128 *)
       let sizeof_msg_wmname = 128
 
   (** Dom0 -> VM *)
@@ -491,8 +491,8 @@ module GUI = struct
         (* this is a 256-bit bitmap of which keys should be enabled*)
         keys : Bytes.t (*uint8_t [@len 32];*)
       }
-      let get_msg_keymap_notify_keys h = h
-      let set_msg_keymap_notify_keys h v = Bytes.blit v 0 h 0 32
+      (* let get_msg_keymap_notify_keys h = h *)
+      (* let set_msg_keymap_notify_keys h v = Bytes.blit v 0 h 0 32 *)
       let sizeof_msg_keymap_notify = 32
 
   (** VM -> Dom0 *)
@@ -552,10 +552,10 @@ module GUI = struct
         (* followed by a variable length buffer of pixels:*)
         (* uint32_t mfns[0]; *)
       }
-      (* let get_shm_cmd_shmid h = Bytes.get_int32_le h 0 *)
-      (* let set_shm_cmd_shmid h v = Bytes.set_int32_le h 0 v *)
-      (* let get_shm_cmd_width h = Bytes.get_int32_le h 4 *)
-      (* let set_shm_cmd_width h v = Bytes.set_int32_le h 4 v *)
+      let get_shm_cmd_shmid h = Bytes.get_int32_le h 0
+      let set_shm_cmd_shmid h v = Bytes.set_int32_le h 0 v
+      let get_shm_cmd_width h = Bytes.get_int32_le h 4
+      let set_shm_cmd_width h v = Bytes.set_int32_le h 4 v
       let get_shm_cmd_height h = Bytes.get_int32_le h 8
       let set_shm_cmd_height h v = Bytes.set_int32_le h 8 v
       let get_shm_cmd_bpp h = Bytes.get_int32_le h 12
@@ -574,10 +574,10 @@ module GUI = struct
         res_class : Bytes.t ; (* uint8_t [@len 64]; *)
         res_name : Bytes.t ;(* uint8_t [@len 64]; *)
       }
-      let get_shm_cmd_shmid h = Bytes.sub h 0 64
-      let set_shm_cmd_shmid h v = Bytes.blit v 0 h 0 64
-      let get_shm_cmd_width h = Bytes.sub h 64 64
-      let set_shm_cmd_width h v = Bytes.blit v 0 h 64 64
+      (* let get_msg_wmclass_res_class h = Bytes.sub h 0 64 *)
+      (* let set_msg_wmclass_res_class h v = Bytes.blit v 0 h 0 64 *)
+      (* let get_msg_wmclass_res_name h = Bytes.sub h 64 64 *)
+      (* let set_msg_wmclass_res_name h v = Bytes.blit v 0 h 64 64 *)
       let sizeof_msg_wmclass = 128
 
     type msg_type =
@@ -861,7 +861,7 @@ module QubesDB = struct
       let get_msg_header_ty h = Bytes.get_uint8 h 0
       let set_msg_header_ty h v = Bytes.set_uint8 h 0 v
       let get_msg_header_path h = Bytes.sub h 1 64
-      let set_msg_header_path h v = Bytes.blit v 0 h 1 64
+      let set_msg_header_path h v = Bytes.blit_string v 0 h 1 (min (String.length v) 64)
       let get_msg_header_data_len h = Bytes.get_int32_le h 68
       let set_msg_header_data_len h v = Bytes.set_int32_le h 68 v
       let sizeof_msg_header = 72
@@ -870,7 +870,7 @@ module QubesDB = struct
   let make_msg_header ~ty ~path ~data_len =
     let msg = Bytes.create sizeof_msg_header in
     set_msg_header_ty msg (qdb_msg_to_int ty);
-    Bytes.blit (Bytes.of_string path) 0 (get_msg_header_path msg) 0 (String.length path);
+    set_msg_header_path msg path;
     set_msg_header_data_len msg (Int32.of_int data_len);
     msg
 

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -1,9 +1,14 @@
 (** The Qubes wire protocol details. *)
 (** for more details, see qubes-gui-common/include/qubes-gui-protocol.h *)
 
+let of_int32_le i =
+  assert(i < Int32.max_int);
+  let i = Int32.to_int i in
+  String.init 4 (fun p -> Char.chr ((i lsr (p*8)) land 0xff))
+
 module type FRAMING = sig
   val header_size : int
-  val body_size_from_header : Bytes.t -> int
+  val body_size_from_header : String.t -> int
 end
 
 module Qrexec = struct
@@ -11,17 +16,17 @@ module Qrexec = struct
         ty : int32;
         len : int32;
       }
-      let get_msg_header_ty h = Bytes.get_int32_le h 0
-      let set_msg_header_ty h v = Bytes.set_int32_le h 0 v
-      let get_msg_header_len h = Bytes.get_int32_le h 4
-      let set_msg_header_len h v = Bytes.set_int32_le h 4 v
+      let get_msg_header_ty h = String.get_int32_le h 0
+      (* let set_msg_header_ty h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_header_len h = String.get_int32_le h 4
+      (* let set_msg_heade.r_len h vString= Bytes.set_int32_le h 4 v *)
       let sizeof_msg_header = 8
 
       type peer_info = {
         version : int32;
       }
-      let get_peer_info_version h = Bytes.get_int32_le h 0
-      let set_peer_info_version h v = Bytes.set_int32_le h 0 v
+      let get_peer_info_version h = String.get_int32_le h 0
+      (* let set_peer_info_version h v = Bytes.set_int32_le h 0 v *)
       let sizeof_peer_info = 4
 
       type exec_params = {
@@ -29,41 +34,41 @@ module Qrexec = struct
         connect_port : int32;
         (* rest of message is command line *)
       }
-      let get_exec_params_connect_domain h = Bytes.get_int32_le h 0
-      let set_exec_params_connect_domain h v = Bytes.set_int32_le h 0 v
-      let get_exec_params_connect_port h = Bytes.get_int32_le h 4
-      let set_exec_params_connect_port h v = Bytes.set_int32_le h 4 v
+      let get_exec_params_connect_domain h = String.get_int32_le h 0
+      (* let set_exec_params_connect_domain h v = Bytes.set_int32_le h 0 v *)
+      let get_exec_params_connect_port h = String.get_int32_le h 4
+      (* let set_exec_params_connect_port h v = Bytes.set_int32_le h 4 v *)
       let sizeof_exec_params = 8
 
       type exit_status = {
         return_code : int32;
       }
-      let get_exit_status_return_code h = Bytes.get_int32_le h 0
-      let set_exit_status_return_code h v = Bytes.set_int32_le h 0 v
+      let get_exit_status_return_code h = String.get_int32_le h 0
+      (* let set_exit_status_return_code h v = Bytes.set_int32_le h 0 v *)
       let sizeof_exit_status = 4
 
       type trigger_service_params = {
-        service_name : Bytes.t; (* [@len 64]; *)
-        target_domain : Bytes.t; (* [@len 32]; *)
-        request_id : Bytes.t; (* [@len 32] *)
+        service_name : String.t; (* [@len 64]; *)
+        target_domain : String.t; (* [@len 32]; *)
+        request_id : String.t; (* [@len 32] *)
       }
-      let get_trigger_service_params_service_name h = Bytes.sub h 0 64
-      let set_trigger_service_params_service_name v ofs h = Bytes.blit_string v 0 h ofs 64
-      let get_trigger_service_params_target_domain h = Bytes.sub h 64 32
-      let set_trigger_service_params_target_domain v ofs h = Bytes.blit_string v 0 h (64+ofs) 32
-      let get_trigger_service_params_request_id h = Bytes.sub h 96 32
-      let set_trigger_service_params_request_id v ofs h = Bytes.blit_string v 0 h (96+ofs) 32
+      let get_trigger_service_params_service_name h = String.sub h 0 64
+      (* let set_trigger_service_params_service_name v ofs h = Bytes.blit_string v 0 h ofs 64 *)
+      let get_trigger_service_params_target_domain h = String.sub h 64 32
+      (* let set_trigger_service_params_target_domain v ofs h = Bytes.blit_string v 0 h (64+ofs) 32 *)
+      let get_trigger_service_params_request_id h = String.sub h 96 32
+      (* let set_trigger_service_params_request_id v ofs h = Bytes.blit_string v 0 h (96+ofs) 32 *)
       let sizeof_trigger_service_params = 64+32+32
 
       type trigger_service_params3 = {
-        target_domain : Bytes.t; (* [@len 64]; *)
-        request_id : Bytes.t; (* [@len 32] *)
+        target_domain : String.t; (* [@len 64]; *)
+        request_id : String.t; (* [@len 32] *)
         (* rest of message is service name *)
       }
-      let get_trigger_service_params3_target_domain h = Bytes.sub h 0 64
-      let set_trigger_service_params3_target_domain v ofs h = Bytes.blit_string v 0 h ofs 64
-      let get_trigger_service_params3_request_id h = Bytes.sub h 64 32
-      let set_trigger_service_params3_request_id v ofs h = Bytes.blit_string v 0 h (64+ofs) 32
+      let get_trigger_service_params3_target_domain h = String.sub h 0 64
+      (* let set_trigger_service_params3_target_domain v ofs h = Bytes.blit_string v 0 h ofs 64 *)
+      let get_trigger_service_params3_request_id h = String.sub h 64 32
+      (* let set_trigger_service_params3_request_id v ofs h = Bytes.blit_string v 0 h (64+ofs) 32 *)
       let sizeof_trigger_service_params3 = 64+32
     
   type msg_type =
@@ -155,8 +160,8 @@ module GUI = struct
       type gui_protocol_version = {
         version : int32;
       }
-      let get_gui_protocol_version_version h = Bytes.get_int32_le h 0
-      let set_gui_protocol_version_version h v = Bytes.set_int32_le h 0 v
+      (* let get_gui_protocol_version_version h = Bytes.get_int32_le h 0 *)
+      (* let set_gui_protocol_version_version h v = Bytes.set_int32_le h 0 v *)
       let sizeof_gui_protocol_version = 4
  
 
@@ -166,12 +171,12 @@ module GUI = struct
         window : int32;
         untrusted_len : int32;
       }
-      let get_msg_header_ty h = Bytes.get_int32_le h 0
-      let set_msg_header_ty h v = Bytes.set_int32_le h 0 v
-      let get_msg_header_window h = Bytes.get_int32_le h 4
-      let set_msg_header_window h v = Bytes.set_int32_le h 4 v
-      let get_msg_header_untrusted_len h = Bytes.get_int32_le h 8
-      let set_msg_header_untrusted_len h v = Bytes.set_int32_le h 8 v
+      let get_msg_header_ty h = String.get_int32_le h 0
+      (* let set._msg_header_ty h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_header_window h = String.get_int32_le h 4
+      (* let set_msg_header_window h v = Bytes.set_int32_le h 4 v *)
+      let get_msg_header_untrusted_len h = String.get_int32_le h 8
+      (* let set_msg_header_untrusted_len h v = Bytes.set_int32_le h 8 v *)
       let sizeof_msg_header = 12
 
   (** VM -> Dom0, Dom0 -> VM *)
@@ -179,10 +184,10 @@ module GUI = struct
         override_redirect : int32;
         transient_for     : int32;
       }
-      let get_msg_map_info_override_redirect h = Bytes.get_int32_le h 0
-      let set_msg_map_info_override_redirect h v = Bytes.set_int32_le h 0 v
-      let get_msg_map_info_transient_for h = Bytes.get_int32_le h 4
-      let set_msg_map_info_transient_for h v = Bytes.set_int32_le h 4 v
+      let get_msg_map_info_override_redirect h = String.get_int32_le h 0
+      (* let set_msg_map_info_override_redirect h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_map_info_transient_for h = String.get_int32_le h 4
+      (* let set_msg_map_info_transient_for h v = Bytes.set_int32_le h 4 v *)
       let sizeof_msg_map_info = 8
 
   (** Dom0 -> VM, dom0 wants us to reply with a MSG_CLIPBOARD_DATA *)
@@ -195,10 +200,10 @@ module GUI = struct
       len : int32;
       (* followed by a uint8 array of size len *)
     }
-      let get_msg_clipboard_data_window_id h = Bytes.get_int32_be h 0
-      let set_msg_clipboard_data_window_id h v = Bytes.set_int32_be h 0 v
-      let get_msg_clipboard_data_len h = Bytes.get_int32_le h 4
-      let set_msg_clipboard_data_len h v = Bytes.set_int32_le h 4 v
+      let get_msg_clipboard_data_window_id h = String.get_int32_be h 0
+      (* let set_msg_clipboard_data_window_id h v = Bytes.set_int32_be h 0 v *)
+      let get_msg_clipboard_data_len h = String.get_int32_le h 4
+      (* let set_msg_clipboard_data_len h v = Bytes.set_int32_le h 4 v *)
       let sizeof_msg_clipboard_data = 8
 
   (** VM -> Dom0 *)
@@ -210,18 +215,18 @@ module GUI = struct
         parent : int32;
         override_redirect : int32;
       }
-      let get_msg_create_x h = Bytes.get_int32_le h 0
-      let set_msg_create_x h v = Bytes.set_int32_le h 0 v
-      let get_msg_create_y h = Bytes.get_int32_le h 4
-      let set_msg_create_y h v = Bytes.set_int32_le h 4 v
-      let get_msg_create_width h = Bytes.get_int32_le h 8
-      let set_msg_create_width h v = Bytes.set_int32_le h 8 v
-      let get_msg_create_height h = Bytes.get_int32_le h 12
-      let set_msg_create_height h v = Bytes.set_int32_le h 12 v
-      let get_msg_create_parent h = Bytes.get_int32_le h 16
-      let set_msg_create_parent h v = Bytes.set_int32_le h 16 v
-      let get_msg_create_override_redirect h = Bytes.get_int32_le h 20
-      let set_msg_create_override_redirect h v = Bytes.set_int32_le h 20 v
+      let get_msg_create_x h = String.get_int32_le h 0
+      (* let set_msg_create_x h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_create_y h = String.get_int32_le h 4
+      (* let set_msg_create_y h v = Bytes.set_int32_le h 4 v *)
+      let get_msg_create_width h = String.get_int32_le h 8
+      (* let set_msg_create_width h v = Bytes.set_int32_le h 8 v *)
+      let get_msg_create_height h = String.get_int32_le h 12
+      (* let set_msg_create_height h v = Bytes.set_int32_le h 12 v *)
+      let get_msg_create_parent h = String.get_int32_le h 16
+      (* let set_msg_create_parent h v = Bytes.set_int32_le h 16 v *)
+      let get_msg_create_override_redirect h = String.get_int32_le h 20
+      (* let set_msg_create_override_redirect h v = Bytes.set_int32_le h 20 v *)
       let sizeof_msg_create = 24
 
   type msg_keypress_t =
@@ -235,6 +240,7 @@ module GUI = struct
 
   (** Dom0 -> VM *)
   (* https://github.com/drinkcat/chroagh/commit/1d38c2e2422f97b6bf55580c9efc027ecf9f2721 *)
+(*
       type msg_keypress = {
         ty    : int32;
         x     : int32;
@@ -242,16 +248,17 @@ module GUI = struct
         state : int32; (** 1:down, 0:up *)
         keycode : int32;
       }
-      let get_msg_keypress_ty h = Bytes.get_int32_le h 0
-      let set_msg_keypress_ty h v = Bytes.set_int32_le h 0 v
-      let get_msg_keypress_x h = Bytes.get_int32_le h 4
-      let set_msg_keypress_x h v = Bytes.set_int32_le h 4 v
-      let get_msg_keypress_y h = Bytes.get_int32_le h 8
-      let set_msg_keypress_y h v = Bytes.set_int32_le h 8 v
-      let get_msg_keypress_state h = Bytes.get_int32_le h 12
-      let set_msg_keypress_state h v = Bytes.set_int32_le h 12 v
-      let get_msg_keypress_keycode h = Bytes.get_int32_le h 16
-      let set_msg_keypress_keycode h v = Bytes.set_int32_le h 16 v
+*)
+      let get_msg_keypress_ty h = String.get_int32_le h 0
+      (* let set_msg_keypress_ty h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_keypress_x h = String.get_int32_le h 4
+      (* let set_msg_keypress_x h v = Bytes.set_int32_le h 4 v *)
+      let get_msg_keypress_y h = String.get_int32_le h 8
+      (* let set_msg_keypress_y h v = Bytes.set_int32_le h 8 v *)
+      let get_msg_keypress_state h = String.get_int32_le h 12
+      (* let set_msg_keypress_state h v = Bytes.set_int32_le h 12 v *)
+      let get_msg_keypress_keycode h = String.get_int32_le h 16
+      (* let set_msg_keypress_keycode h v = Bytes.set_int32_le h 16 v *)
       let sizeof_msg_keypress = 20
 
 
@@ -263,6 +270,7 @@ module GUI = struct
     button: int32 ;
   }
 
+(*
   (** Dom0 -> VM, TODO seems to be mouse buttons? *)
    type msg_button = {
      ty : int32;
@@ -271,16 +279,17 @@ module GUI = struct
      state : int32;
      button : int32; (* TODO *)
    }
-   let get_msg_button_ty h = Bytes.get_int32_le h 0
-   let set_msg_button_ty h v = Bytes.set_int32_le h 0 v
-   let get_msg_button_x h = Bytes.get_int32_le h 4
-   let set_msg_button_x h v = Bytes.set_int32_le h 4 v
-   let get_msg_button_y h = Bytes.get_int32_le h 8
-   let set_msg_button_y h v = Bytes.set_int32_le h 8 v
-   let get_msg_button_state h = Bytes.get_int32_le h 12
-   let set_msg_button_state h v = Bytes.set_int32_le h 12 v
-   let get_msg_button_button h = Bytes.get_int32_le h 16
-   let set_msg_button_button h v = Bytes.set_int32_le h 16 v
+*)
+   let get_msg_button_ty h = String.get_int32_le h 0
+   (* let set_msg_button_ty h v = Bytes.set_int32_le h 0 v *)
+   let get_msg_button_x h = String.get_int32_le h 4
+   (* let set_msg_button_x h v = Bytes.set_int32_le h 4 v *)
+   let get_msg_button_y h = String.get_int32_le h 8
+   (* let set_msg_button_y h v = Bytes.set_int32_le h 8 v *)
+   let get_msg_button_state h = String.get_int32_le h 12
+   (* let set_msg_button_state h v = Bytes.set_int32_le h 12 v *)
+   let get_msg_button_button h = String.get_int32_le h 16
+   (* let set_msg_button_button h v = Bytes.set_int32_le h 16 v *)
    let sizeof_msg_button = 20
 
   let decode_msg_button b: msg_button_t option =
@@ -299,29 +308,18 @@ module GUI = struct
     is_hint : int;
   }
 
-  (** Dom0 -> VM, mouse / cursor motion event *)
-      type msg_motion = {
-        x       : int32;
-        y       : int32;
-        state   : int32;
-        is_hint : int32;
-      }
-      let get_msg_motion_x h = Bytes.get_int32_le h 0
-      let set_msg_motion_x h v = Bytes.set_int32_le h 0 v
-      let get_msg_motion_y h = Bytes.get_int32_le h 4
-      let set_msg_motion_y h v = Bytes.set_int32_le h 4 v
-      let get_msg_motion_state h = Bytes.get_int32_le h 8
-      let set_msg_motion_state h v = Bytes.set_int32_le h 8 v
-      let get_msg_motion_is_hint h = Bytes.get_int32_le h 12
-      let set_msg_motion_is_hint h v = Bytes.set_int32_le h 12 v
+      let get_msg_motion_x h = String.get_int32_le h 0
+      let get_msg_motion_y h = String.get_int32_le h 4
+      let get_msg_motion_state h = String.get_int32_le h 8
+      let get_msg_motion_is_hint h = String.get_int32_le h 12
       let sizeof_msg_motion = 16
 
-  let decode_msg_motion cs : msg_motion_t option = (*TODO catch exceptions *)
-  let i32 = fun f -> (f cs |> Int32.to_int) in
+  let decode_msg_motion str : msg_motion_t option = (*TODO catch exceptions *)
+  let i32 = fun f -> (f str |> Int32.to_int) in
   Some ({
       x = i32 get_msg_motion_x
    ;  y = i32 get_msg_motion_y
-   ;  state  = get_msg_motion_state cs
+   ;  state  = get_msg_motion_state str
    ; is_hint = i32 get_msg_motion_is_hint
    } : msg_motion_t)
 
@@ -336,6 +334,7 @@ module GUI = struct
     focus  : int32;
   }
 
+(*
   (** Dom0 -> VM, seems to fire when the mouse is moved over a window border *)
    type msg_crossing = {
      ty : int32;
@@ -346,54 +345,37 @@ module GUI = struct
      detail : int32;
      focus  : int32;
    }
-   let get_msg_crossing_ty h = Bytes.get_int32_le h 0
-   let set_msg_crossing_ty h v = Bytes.set_int32_le h 0 v
-   let get_msg_crossing_x h = Bytes.get_int32_le h 4
-   let set_msg_crossing_x h v = Bytes.set_int32_le h 4 v
-   let get_msg_crossing_y h = Bytes.get_int32_le h 8
-   let set_msg_crossing_y h v = Bytes.set_int32_le h 8 v
-   let get_msg_crossing_state h = Bytes.get_int32_le h 12
-   let set_msg_crossing_state h v = Bytes.set_int32_le h 12 v
-   let get_msg_crossing_mode h = Bytes.get_int32_le h 16
-   let set_msg_crossing_mode h v = Bytes.set_int32_le h 16 v
-   let get_msg_crossing_detail h = Bytes.get_int32_le h 20
-   let set_msg_crossing_detail h v = Bytes.set_int32_le h 20 v
-   let get_msg_crossing_focus h = Bytes.get_int32_le h 24
-   let set_msg_crossing_focus h v = Bytes.set_int32_le h 24 v
+*)
+   let get_msg_crossing_ty h = String.get_int32_le h 0
+   (* let set_msg_crossing_ty h v = Bytes.set_int32_le h 0 v *)
+   let get_msg_crossing_x h = String.get_int32_le h 4
+   (* let set_msg_crossing_x h v = Bytes.set_int32_le h 4 v *)
+   let get_msg_crossing_y h = String.get_int32_le h 8
+   (* let set_msg_crossing_y h v = Bytes.set_int32_le h 8 v *)
+   let get_msg_crossing_state h = String.get_int32_le h 12
+   (* let set_msg_crossing_state h v = Bytes.set_int32_le h 12 v *)
+   let get_msg_crossing_mode h = String.get_int32_le h 16
+   (* let set_msg_crossing_mode h v = Bytes.set_int32_le h 16 v *)
+   let get_msg_crossing_detail h = String.get_int32_le h 20
+   (* let set_msg_crossing_detail h v = Bytes.set_int32_le h 20 v *)
+   let get_msg_crossing_focus h = String.get_int32_le h 24
+   (* let set_msg_crossing_focus h v = Bytes.set_int32_le h 24 v *)
    let sizeof_msg_crossing = 28
 
-  let decode_msg_crossing cs  : msg_crossing_t option =
+  let decode_msg_crossing str  : msg_crossing_t option =
      (*TODO catch exceptions *)
-    Some ({ ty = get_msg_crossing_ty cs
-          ;  x = get_msg_crossing_x  cs
-          ;  y = get_msg_crossing_y  cs
-          ;  state = get_msg_crossing_state  cs
-          ;   mode = get_msg_crossing_mode   cs
-          ; detail = get_msg_crossing_detail cs
-          ;  focus = get_msg_crossing_focus  cs
+    Some ({ ty = get_msg_crossing_ty str
+          ;  x = get_msg_crossing_x  str
+          ;  y = get_msg_crossing_y  str
+          ;  state = get_msg_crossing_state  str
+          ;   mode = get_msg_crossing_mode   str
+          ; detail = get_msg_crossing_detail str
+          ;  focus = get_msg_crossing_focus  str
           } : msg_crossing_t)
 
   (** VM -> Dom0, Dom0 -> VM, note that when you send this you must read the
                           "corrected" MSG_CONFIGURE you get back and use those
                           values instead of your own *)
-      type msg_configure = {
-        x      : int32;
-        y      : int32;
-        width  : int32;
-        height : int32;
-        override_redirect : int32;
-      }
-      let get_msg_configure_x h = Bytes.get_int32_le h 0
-      let set_msg_configure_x h v = Bytes.set_int32_le h 0 v
-      let get_msg_configure_y h = Bytes.get_int32_le h 4
-      let set_msg_configure_y h v = Bytes.set_int32_le h 4 v
-      let get_msg_configure_width h = Bytes.get_int32_le h 8
-      let set_msg_configure_width h v = Bytes.set_int32_le h 8 v
-      let get_msg_configure_height h = Bytes.get_int32_le h 12
-      let set_msg_configure_height h v = Bytes.set_int32_le h 12 v
-      let get_msg_configure_override_redirect h = Bytes.get_int32_le h 16
-      let set_msg_configure_override_redirect h v = Bytes.set_int32_le h 16 v
-      let sizeof_msg_configure = 20
 
   type msg_configure_t = {
     x: int32;
@@ -402,13 +384,32 @@ module GUI = struct
     height: int32;
     override_redirect: int32;
   }
+(*      type msg_configure = {
+        x      : int32;
+        y      : int32;
+        width  : int32;
+        height : int32;
+        override_redirect : int32;
+      }
+*)
+      let get_msg_configure_x h = String.get_int32_le h 0
+      (* let set_msg_configure_x h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_configure_y h = String.get_int32_le h 4
+      (* let set_msg_configure_y h v = Bytes.set_int32_le h 4 v *)
+      let get_msg_configure_width h = String.get_int32_le h 8
+      (* let set_msg_configure_width h v = Bytes.set_int32_le h 8 v *)
+      let get_msg_configure_height h = String.get_int32_le h 12
+      (* let set_msg_configure_height h v = Bytes.set_int32_le h 12 v *)
+      let get_msg_configure_override_redirect h = String.get_int32_le h 16
+      (* let set_msg_configure_override_redirect h v = Bytes.set_int32_le h 16 v *)
+      let sizeof_msg_configure = 20
 
-  let decode_msg_configure cs : msg_configure_t option =
-    Some ({ x = get_msg_configure_x cs ;
-            y = get_msg_configure_y cs ;
-            width = get_msg_configure_width cs ;
-            height = get_msg_configure_height cs ;
-            override_redirect = get_msg_configure_override_redirect cs ;
+  let decode_msg_configure b : msg_configure_t option =
+    Some ({ x = get_msg_configure_x b ;
+            y = get_msg_configure_y b ;
+            width = get_msg_configure_width b ;
+            height = get_msg_configure_height b ;
+            override_redirect = get_msg_configure_override_redirect b ;
           } : msg_configure_t)
 
     (** VM -> Dom0 *)
@@ -418,20 +419,20 @@ module GUI = struct
         width : int32;
         height: int32;
       }
-      let get_msg_shmimage_x h = Bytes.get_int32_le h 0
-      let set_msg_shmimage_x h v = Bytes.set_int32_le h 0 v
-      let get_msg_shmimage_y h = Bytes.get_int32_le h 4
-      let set_msg_shmimage_y h v = Bytes.set_int32_le h 4 v
-      let get_msg_shmimage_width h = Bytes.get_int32_le h 8
-      let set_msg_shmimage_width h v = Bytes.set_int32_le h 8 v
-      let get_msg_shmimage_height h = Bytes.get_int32_le h 12
-      let set_msg_shmimage_height h v = Bytes.set_int32_le h 12 v
+      let get_msg_shmimage_x h = String.get_int32_le h 0
+      (* let set_msg_shmimage_x h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_shmimage_y h = String.get_int32_le h 4
+      (* let set_msg_shmimage_y h v = Bytes.set_int32_le h 4 v *)
+      let get_msg_shmimage_width h = String.get_int32_le h 8
+      (* let set_msg_shmimage_width h v = Bytes.set_int32_le h 8 v *)
+      let get_msg_shmimage_height h = String.get_int32_le h 12
+      (* let set_msg_shmimage_height h v = Bytes.set_int32_le h 12 v *)
       let sizeof_msg_shmimage = 16
 
 
   type msg_focus_t = {
-    mode : Cstruct.uint32;
-    detail: Cstruct.uint32;
+    mode : int32;
+    detail: int32;
   }
 
   (** Dom0 -> VM *)
@@ -440,17 +441,17 @@ module GUI = struct
         mode   : int32;
         detail : int32;
       }
-      let get_msg_focus_ty h = Bytes.get_int32_le h 0
-      let set_msg_focus_ty h v = Bytes.set_int32_le h 0 v
-      let get_msg_focus_mode h = Bytes.get_int32_le h 4
-      let set_msg_focus_mode h v = Bytes.set_int32_le h 4 v
-      let get_msg_focus_detail h = Bytes.get_int32_le h 8
-      let set_msg_focus_detail h v = Bytes.set_int32_le h 8 v
+      let get_msg_focus_ty h = String.get_int32_le h 0
+      (* let set_msg_focus_ty h v = Bytes.set_int32_le h 0 v *)
+      let get_msg_focus_mode h = String.get_int32_le h 4
+      (* let set_msg_focus_mode h v = Bytes.set_int32_le h 4 v *)
+      let get_msg_focus_detail h = String.get_int32_le h 8
+      (* let set_msg_focus_detail h v = Bytes.set_int32_le h 8 v *)
       let sizeof_msg_focus = 12
 
   (* Dom0 -> VM *)
       type msg_execute = {
-        cmd: Bytes.t; (* uint8_t [@len 255]; *)
+        cmd: String.t; (* uint8_t [@len 255]; *)
       }
       (* let get_msg_execute_cmd h = h *)
       (* let set_msg_execute_cmd h v = Bytes.blit v 0 h 0 255 *)
@@ -466,21 +467,21 @@ module GUI = struct
     linear frame buffer. This entry is not used by many drivers, and it should
     only be specified if the driver-specific documentation recommends it. *)
       }
-      let get_xconf_w h = Bytes.get_int32_le h 0
-      let set_xconf_w h v = Bytes.set_int32_le h 0 v
-      let get_xconf_h h = Bytes.get_int32_le h 4
-      let set_xconf_h h v = Bytes.set_int32_le h 4 v
-      let get_xconf_depth h = Bytes.get_int32_le h 8
-      let set_xconf_depth h v = Bytes.set_int32_le h 8 v
-      let get_xconf_mem h = Bytes.get_int32_le h 12
-      let set_xconf_mem h v = Bytes.set_int32_le h 12 v
+      let get_xconf_w h = String.get_int32_le h 0
+      (* let set_xconf_w h v = Bytes.set_int32_le h 0 v *)
+      let get_xconf_h h = String.get_int32_le h 4
+      (* let set_xconf_h h v = Bytes.set_int32_le h 4 v *)
+      let get_xconf_depth h = String.get_int32_le h 8
+      (* let set_xconf_depth h v = Bytes.set_int32_le h 8 v *)
+      let get_xconf_mem h = String.get_int32_le h 12
+      (* let set_xconf_mem h v = Bytes.set_int32_le h 12 v *)
       let sizeof_xconf = 16
 
   (* https://tronche.com/gui/x/icccm/sec-4.html#WM_TRANSIENT_FOR *)
 
   (** VM -> Dom0 *)
       type msg_wmname = {
-        data : Bytes.t (*uint8_t  [@len 128];*) (* title of the window *)
+        data : String.t (*uint8_t  [@len 128];*) (* title of the window *)
       }
       (* let get_msg_wmname_data h = h *)
       (* let set_msg_wmname_data h v = Bytes.blit v 0 h 0 128 *)
@@ -489,7 +490,7 @@ module GUI = struct
   (** Dom0 -> VM *)
       type msg_keymap_notify = {
         (* this is a 256-bit bitmap of which keys should be enabled*)
-        keys : Bytes.t (*uint8_t [@len 32];*)
+        keys : String.t (*uint8_t [@len 32];*)
       }
       (* let get_msg_keymap_notify_keys h = h *)
       (* let set_msg_keymap_notify_keys h v = Bytes.blit v 0 h 0 32 *)
@@ -508,24 +509,24 @@ module GUI = struct
         base_width: int32;
         base_height: int32;
       }
-      let get_msg_window_hints_flags h = Bytes.get_int32_le h 0
-      let set_msg_window_hints_flags h v = Bytes.set_int32_le h 0 v
-      let get_msg_window_hints_min_width h = Bytes.get_int32_le h 4
-      let set_msg_window_hints_min_width h v = Bytes.set_int32_le h 4 v
-      let get_msg_window_hints_min_height h = Bytes.get_int32_le h 8
-      let set_msg_window_hints_min_height h v = Bytes.set_int32_le h 8 v
-      let get_msg_window_hints_max_width h = Bytes.get_int32_le h 12
-      let set_msg_window_hints_max_width h v = Bytes.set_int32_le h 12 v
-      let get_msg_window_hints_max_height h = Bytes.get_int32_le h 16
-      let set_msg_window_hints_max_height h v = Bytes.set_int32_le h 16 v
-      let get_msg_window_hints_width_inc h = Bytes.get_int32_le h 20
-      let set_msg_window_hints_width_inc h v = Bytes.set_int32_le h 20 v
-      let get_msg_window_hints_height_inc h = Bytes.get_int32_le h 24
-      let set_msg_window_hints_height_inc h v = Bytes.set_int32_le h 24 v
-      let get_msg_window_hints_base_width h = Bytes.get_int32_le h 28
-      let set_msg_window_hints_base_width h v = Bytes.set_int32_le h 28 v
-      let get_msg_window_hints_base_height h = Bytes.get_int32_le h 32
-      let set_msg_window_hints_base_height h v = Bytes.set_int32_le h 32 v
+      (* let get_msg_window_hints_flags h = String.get_int32_le h 0 *)
+      (* let set_msg_window_hints_flags h v = Bytes.set_int32_le h 0 v *)
+      (* let get_msg_window_hints_min_width h = String.get_int32_le h 4 *)
+      (* let set_msg_window_hints_min_width h v = Bytes.set_int32_le h 4 v *)
+      (* let get_msg_window_hints_min_height h = String.get_int32_le h 8 *)
+      (* let set_msg_window_hints_min_height h v = Bytes.set_int32_le h 8 v *)
+      (* let get_msg_window_hints_max_width h = String.get_int32_le h 12 *)
+      (* let set_msg_window_hints_max_width h v = Bytes.set_int32_le h 12 v *)
+      (* let get_msg_window_hints_max_height h = String.get_int32_le h 16 *)
+      (* let set_msg_window_hints_max_height h v = Bytes.set_int32_le h 16 v *)
+      (* let get_msg_window_hints_width_inc h = String.get_int32_le h 20 *)
+      (* let set_msg_window_hints_width_inc h v = Bytes.set_int32_le h 20 v *)
+      (* let get_msg_window_hints_height_inc h = String.get_int32_le h 24 *)
+      (* let set_msg_window_hints_height_inc h v = Bytes.set_int32_le h 24 v *)
+      (* let get_msg_window_hints_base_width h = String.get_int32_le h 28 *)
+      (* let set_msg_window_hints_base_width h v = Bytes.set_int32_le h 28 v *)
+      (* let get_msg_window_hints_base_height h = String.get_int32_le h 32 *)
+      (* let set_msg_window_hints_base_height h v = Bytes.set_int32_le h 32 v *)
       let sizeof_msg_window_hints = 36
 
   (** VM -> Dom0, Dom0 -> VM *)
@@ -534,10 +535,10 @@ module GUI = struct
         flags_set   : int32;
         flags_unset : int32;
       }
-      let get_msg_window_flags_flags_set h = Bytes.get_int32_le h 0
-      let set_msg_window_flags_flags_set h v = Bytes.set_int32_le h 0 v
-      let get_msg_window_flags_flags_unset h = Bytes.get_int32_le h 4
-      let set_msg_window_flags_flags_unset h v = Bytes.set_int32_le h 4 v
+      (* let get_msg_window_flags_flags_set h = Bytes.get_int32_le h 0 *)
+      (* let set_msg_window_flags_flags_set h v = Bytes.set_int32_le h 0 v *)
+      (* let get_msg_window_flags_flags_unset h = Bytes.get_int32_le h 4 *)
+      (* let set_msg_window_flags_flags_unset h v = Bytes.set_int32_le h 4 v *)
       let sizeof_msg_window_flags = 8
 
   (** VM -> Dom0 *)
@@ -552,27 +553,27 @@ module GUI = struct
         (* followed by a variable length buffer of pixels:*)
         (* uint32_t mfns[0]; *)
       }
-      let get_shm_cmd_shmid h = Bytes.get_int32_le h 0
-      let set_shm_cmd_shmid h v = Bytes.set_int32_le h 0 v
-      let get_shm_cmd_width h = Bytes.get_int32_le h 4
-      let set_shm_cmd_width h v = Bytes.set_int32_le h 4 v
-      let get_shm_cmd_height h = Bytes.get_int32_le h 8
-      let set_shm_cmd_height h v = Bytes.set_int32_le h 8 v
-      let get_shm_cmd_bpp h = Bytes.get_int32_le h 12
-      let set_shm_cmd_bpp h v = Bytes.set_int32_le h 12 v
-      let get_shm_cmd_off h = Bytes.get_int32_le h 16
-      let set_shm_cmd_off h v = Bytes.set_int32_le h 16 v
-      let get_shm_cmd_num_mfn h = Bytes.get_int32_le h 20
-      let set_shm_cmd_num_mfn h v = Bytes.set_int32_le h 20 v
-      let get_shm_cmd_domid h = Bytes.get_int32_le h 24
-      let set_shm_cmd_domid h v = Bytes.set_int32_le h 24 v
+      (* let get_shm_cmd_shmid h = Bytes.get_int32_le h 0 *)
+      (* let set_shm_cmd_shmid h v = Bytes.set_int32_le h 0 v *)
+      (* let get_shm_cmd_width h = Bytes.get_int32_le h 4 *)
+      (* let set_shm_cmd_width h v = Bytes.set_int32_le h 4 v *)
+      (* let get_shm_cmd_height h = Bytes.get_int32_le h 8 *)
+      (* let set_shm_cmd_height h v = Bytes.set_int32_le h 8 v *)
+      (* let get_shm_cmd_bpp h = Bytes.get_int32_le h 12 *)
+      (* let set_shm_cmd_bpp h v = Bytes.set_int32_le h 12 v *)
+      (* let get_shm_cmd_off h = Bytes.get_int32_le h 16 *)
+      (* let set_shm_cmd_off h v = Bytes.set_int32_le h 16 v *)
+      (* let get_shm_cmd_num_mfn h = Bytes.get_int32_le h 20 *)
+      (* let set_shm_cmd_num_mfn h v = Bytes.set_int32_le h 20 v *)
+      (* let get_shm_cmd_domid h = Bytes.get_int32_le h 24 *)
+      (* let set_shm_cmd_domid h v = Bytes.set_int32_le h 24 v *)
       let sizeof_shm_cmd = 28
       
 
   (** VM -> Dom0 *)
       type msg_wmclass = {
-        res_class : Bytes.t ; (* uint8_t [@len 64]; *)
-        res_name : Bytes.t ;(* uint8_t [@len 64]; *)
+        res_class : String.t ; (* uint8_t [@len 64]; *)
+        res_name : String.t ;(* uint8_t [@len 64]; *)
       }
       (* let get_msg_wmclass_res_class h = Bytes.sub h 0 64 *)
       (* let set_msg_wmclass_res_class h v = Bytes.blit v 0 h 0 64 *)
@@ -692,90 +693,98 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
    *)
   (* type mfn : uint32_t;  big-endian 24-bit RGB pixel *)
 
-  let make_with_header ~window ~ty body =
+  let make_with_header ~window ~ty ~body_len body =
     (** see qubes-gui-agent-linux/include/txrx.h:#define write_message *)
-    (** TODO consider using Cstruct.add_len *)
-    let body_len = Bytes.length body in
-    let msg = Bytes.create (sizeof_msg_header + body_len) in
-    let()= set_msg_header_ty     msg (msg_type_to_int ty) in
-    let()= set_msg_header_window msg window in
-    let()= set_msg_header_untrusted_len msg Int32.(of_int body_len) in
-    let() = Bytes.blit
-        (* src, srcoff: *) body 0
-        (* dst, dstoff: *) msg sizeof_msg_header
-        (* length: *)      Bytes.(length body)
-    in msg
+    String.concat String.empty [
+      of_int32_le (msg_type_to_int ty) ;
+      of_int32_le window ;
+      of_int32_le body_len ;
+      body
+    ]
 
   let make_msg_mfndump ~window ~width ~height ~mfns =
     (* n.b. must be followed by a MSG_SHMIMAGE to actually repaint *)
     let num_mfn = List.length mfns in
     let offset  = 0x0l in
-    let body = Bytes.create (sizeof_shm_cmd + num_mfn*4) in
-    set_shm_cmd_width   body width;
-    set_shm_cmd_height  body height;
-    set_shm_cmd_bpp     body 24l; (* bits per pixel *)
-    set_shm_cmd_off     body offset;
-    set_shm_cmd_num_mfn body Int32.(of_int num_mfn);
+    (* TODO let n = (4 * width * height + offset
+                     + (XC_PAGE_SIZE-1)) / XC_PAGE_SIZE; *)
+    let cmds = mfns |> List.mapi (fun i -> fun _ ->
+        of_int32_le (Int32.of_int (sizeof_shm_cmd + i*4))) in
+    let body = String.concat String.empty @@ List.append [
+        of_int32_le width ;
+        of_int32_le height ;
+        of_int32_le 24l ; (* bits per pixel *)
+        of_int32_le offset ;
+        of_int32_le @@ Int32.of_int (num_mfn) ;
+    ] cmds in
     (* From https://www.qubes-os.org/doc/gui/
        >> "shmid" and "domid" parameters are just placeholders (to be filled
        >> by *qubes_guid* ), so that we can use the same structure when talking
        >> to shmoverride.so **)
 
-    (* TODO let n = (4 * width * height + offset
-                     + (XC_PAGE_SIZE-1)) / XC_PAGE_SIZE; *)
-    mfns |> List.iteri (fun i ->
-        Bytes.set_int32_le body (sizeof_shm_cmd + i*4));
-    make_with_header ~window ~ty:MSG_MFNDUMP body
+    let body_len = Int32.of_int (sizeof_shm_cmd + num_mfn*4) in
+    make_with_header ~window ~ty:MSG_MFNDUMP ~body_len body
 
   let make_msg_shmimage ~window ~x ~y ~width ~height =
-    let body = Bytes.create (sizeof_msg_shmimage) in
-    set_msg_shmimage_x body x;
-    set_msg_shmimage_y body y;
-    set_msg_shmimage_width body width;
-    set_msg_shmimage_height body height;
-    make_with_header ~window ~ty:MSG_SHMIMAGE body
+    let body = String.concat String.empty [
+        of_int32_le x ;
+        of_int32_le y ;
+        of_int32_le width ;
+        of_int32_le height ;
+    ] in
+    let body_len = Int32.of_int sizeof_msg_shmimage in
+    make_with_header ~window ~ty:MSG_SHMIMAGE ~body_len body
 
   let make_msg_create ~window ~width ~height ~x ~y ~override_redirect ~parent =
-    let body = Bytes.create sizeof_msg_create in
-    set_msg_create_width             body width; (*  w *)
-    set_msg_create_height            body height; (* h *)
-    set_msg_create_x                 body x;
-    set_msg_create_y                 body y;
-    set_msg_create_override_redirect body override_redirect;
-    set_msg_create_parent            body parent;
-    make_with_header ~window ~ty:MSG_CREATE body
+    let body = String.concat String.empty [
+        of_int32_le width ;
+        of_int32_le height ;
+        of_int32_le x ;
+        of_int32_le y ;
+        of_int32_le override_redirect ;
+        of_int32_le parent ;
+    ] in
+    let body_len = Int32.of_int sizeof_msg_create in
+    make_with_header ~window ~ty:MSG_CREATE ~body_len body
 
   let make_msg_map_info ~window ~override_redirect ~transient_for =
-    let body = Bytes.create sizeof_msg_map_info in
-    let()= set_msg_map_info_override_redirect body override_redirect in
-    let()= set_msg_map_info_transient_for body transient_for in
-    make_with_header ~window ~ty:MSG_MAP body
+    let body = String.concat String.empty [
+        of_int32_le override_redirect ;
+        of_int32_le transient_for ;
+    ] in
+    let body_len = Int32.of_int sizeof_msg_map_info in
+    make_with_header ~window ~ty:MSG_MAP ~body_len body
 
   let make_msg_wmname ~window ~wmname =
-    let body = Bytes.create sizeof_msg_wmname in
-    let()= Bytes.blit (Bytes.of_string wmname) 0 body 0
-      (min String.(length wmname) sizeof_msg_wmname) ; (* length *) in
-    make_with_header ~window ~ty:MSG_WMNAME body
+    let body = String.concat String.empty [
+        wmname ;
+        String.make (sizeof_msg_wmname-String.(length wmname)) '\000' ; (* padding to sizeof_msg_wmname *)
+    ] in
+    let body_len = Int32.of_int sizeof_msg_wmname in
+    make_with_header ~window ~ty:MSG_WMNAME ~body_len body
 
   let make_msg_window_hints ~window ~width ~height =
-    let body = Bytes.create sizeof_msg_window_hints in
-    set_msg_window_hints_flags body Int32.(16 lor 32 |> of_int) ;
+    let body = String.concat String.empty [
+        of_int32_le @@ Int32.(16 lor 32 |> of_int) ;
        (*^--  PMinSize | PMaxSize *)
-    set_msg_window_hints_min_width body width;
-    set_msg_window_hints_min_height body height;
-    set_msg_window_hints_max_width body width;
-    set_msg_window_hints_max_height body height;
-    make_with_header ~window ~ty:MSG_WINDOW_HINTS body
+        of_int32_le width ;  (* min width *)
+        of_int32_le height ; (* min height *)
+        of_int32_le width ;  (* max width *)
+        of_int32_le height ; (* max height *)
+    ] in
+    let body_len = Int32.of_int sizeof_msg_window_hints in
+    make_with_header ~window ~ty:MSG_WINDOW_HINTS ~body_len body
 
   let make_msg_configure ~window ~x ~y ~width ~height =
-    let body  = Bytes.create sizeof_msg_configure in
-    set_msg_configure_x body x ;
-    set_msg_configure_y body y ; (* x and y are from qs->window_x and window_y*)
-
-    set_msg_configure_width body width ;
-    set_msg_configure_height body height ;
-    set_msg_configure_override_redirect body 0l ;
-    make_with_header ~window ~ty:MSG_CONFIGURE body
+    let body = String.concat String.empty [
+        of_int32_le x ;
+        of_int32_le y ; (* x and y are from qs->window_x and window_y*)
+        of_int32_le width ;
+        of_int32_le height ;
+        of_int32_le 0l ; (* override_redirect *)
+    ] in
+    let body_len = Int32.of_int sizeof_msg_window_hints in
+    make_with_header ~window ~ty:MSG_CONFIGURE ~body_len body
 
   module Framing = struct
     let header_size = sizeof_msg_header
@@ -853,26 +862,28 @@ module QubesDB = struct
 
       type msg_header = {
         ty        : int;
-        path      : Bytes.t; (* [@len 64]; *)
-        padding   : Bytes.t; (* [@len 3]; *)
+        path      : String.t; (* [@len 64]; *)
+        padding   : String.t; (* [@len 3]; *)
         data_len  : int32;
         (* rest of message is data *)
       }
-      let get_msg_header_ty h = Bytes.get_uint8 h 0
-      let set_msg_header_ty h v = Bytes.set_uint8 h 0 v
-      let get_msg_header_path h = Bytes.sub h 1 64
-      let set_msg_header_path h v = Bytes.blit_string v 0 h 1 (min (String.length v) 64)
-      let get_msg_header_data_len h = Bytes.get_int32_le h 68
-      let set_msg_header_data_len h v = Bytes.set_int32_le h 68 v
+      let get_msg_header_ty h = String.get_uint8 h 0
+      (* let set_msg_header_ty h v = Bytes.set_uint8 h 0 v *)
+      let get_msg_header_path h = String.sub h 1 64
+      (* let set_msg_header_path h v = Bytes.blit_string v 0 h 1 (min (String.length v) 64) *)
+      let get_msg_header_data_len h = String.get_int32_le h 68
+      (* let set_msg_header_data_len h v = Bytes.set_int32_le h 68 v *)
       let sizeof_msg_header = 72
 
 
   let make_msg_header ~ty ~path ~data_len =
-    let msg = Bytes.make sizeof_msg_header '\x00' in
-    set_msg_header_ty msg (qdb_msg_to_int ty);
-    set_msg_header_path msg path;
-    set_msg_header_data_len msg (Int32.of_int data_len);
-    msg
+    assert(String.length path <= 64);
+    String.concat String.empty [
+        String.make 1 (Char.chr (qdb_msg_to_int ty)) ; (* int8 *)
+        path ;
+        String.make (3+64-String.length path) '\000' ; (* padding=3 and max size of path=64 *)
+        of_int32_le (Int32.of_int data_len) ;
+    ]
 
   module Framing = struct
     let header_size = sizeof_msg_header
@@ -893,20 +904,20 @@ module Rpc_filecopy = struct
         mtime_nsec : int32;
       }
       (* followed by filename[namelen] and data[filelen] *)
-      let get_file_header_namelen h = Bytes.get_int32_le h 0
-      let set_file_header_namelen h v = Bytes.set_int32_le h 0 v
-      let get_file_header_mode h = Bytes.get_int32_le h 4
-      let set_file_header_mode h v = Bytes.set_int32_le h 4 v
-      let get_file_header_filelen h = Bytes.get_int64_le h 8
-      let set_file_header_filelen h v = Bytes.set_int64_le h 8 v
-      let get_file_header_atime h = Bytes.get_int32_le h 16
-      let set_file_header_atime h v = Bytes.set_int32_le h 16 v
-      let get_file_header_atime_nsec h = Bytes.get_int32_le h 20
-      let set_file_header_atime_nsec h v = Bytes.set_int32_le h 20 v
-      let get_file_header_mtime h = Bytes.get_int32_le h 24
-      let set_file_header_mtime h v = Bytes.set_int32_le h 24 v
-      let get_file_header_mtime_nsec h = Bytes.get_int32_le h 28
-      let set_file_header_mtime_nsec h v = Bytes.set_int32_le h 28 v
+      (* let get_file_header_namelen h = Bytes.get_int32_le h 0 *)
+      (* let set_file_header_namelen h v = Bytes.set_int32_le h 0 v *)
+      (* let get_file_header_mode h = Bytes.get_int32_le h 4 *)
+      (* let set_file_header_mode h v = Bytes.set_int32_le h 4 v *)
+      (* let get_file_header_filelen h = Bytes.get_int64_le h 8 *)
+      (* let set_file_header_filelen h v = Bytes.set_int64_le h 8 v *)
+      (* let get_file_header_atime h = Bytes.get_int32_le h 16 *)
+      (* let set_file_header_atime h v = Bytes.set_int32_le h 16 v *)
+      (* let get_file_header_atime_nsec h = Bytes.get_int32_le h 20 *)
+      (* let set_file_header_atime_nsec h v = Bytes.set_int32_le h 20 v *)
+      (* let get_file_header_mtime h = Bytes.get_int32_le h 24 *)
+      (* let set_file_header_mtime h v = Bytes.set_int32_le h 24 v *)
+      (* let get_file_header_mtime_nsec h = Bytes.get_int32_le h 28 *)
+      (* let set_file_header_mtime_nsec h v = Bytes.set_int32_le h 28 v *)
       let sizeof_file_header = 32
 
       type result_header = {
@@ -914,28 +925,29 @@ module Rpc_filecopy = struct
         _pad       : int32;
         crc32      : int64;
       }
-      let get_result_header_error_code h = Bytes.get_int32_le h 0
-      let set_result_header_error_code h v = Bytes.set_int32_le h 0 v
+      (* let get_result_header_error_code h = Bytes.get_int32_le h 0 *)
+      (* let set_result_header_error_code h v = Bytes.set_int32_le h 0 v *)
       (* let get_result_header__pad h = Bytes.get_int32_le h 4 *)
       (* let set_result_header__pad h v = Bytes.set_int32_le h 4 v *)
-      let get_result_header_crc32 h = Bytes.get_int64_le h 8
-      let set_result_header_crc32 h v = Bytes.set_int64_le h 8 v
+      (* let get_result_header_crc32 h = Bytes.get_int64_le h 8 *)
+      (* let set_result_header_crc32 h v = Bytes.set_int64_le h 8 v *)
       let sizeof_result_header = 16
 
       type result_header_ext = {
         last_namelen : int32;
         (* TODO char last_name[0]; variable length[last_namelen] *)
       }
-      let get_result_header_ext_last_namelen h = Bytes.get_int32_le h 0
-      let set_result_header_ext_last_namelen h v = Bytes.set_int32_le h 0 v
+      (* let get_result_header_ext_last_namelen h = Bytes.get_int32_le h 0 *)
+      (* let set_result_header_ext_last_namelen h v = Bytes.set_int32_le h 0 v *)
       let sizeof_result_header_ext = 4
 
+(*
   let make_result_header_ext last_filename =
     let namelen = Bytes.length last_filename in
-    let msg = Bytes.create (sizeof_result_header_ext + namelen) in
-    set_result_header_ext_last_namelen msg (Int32.of_int namelen);
-    Bytes.blit (* src  srcoff *) last_filename 0
-               (* dst  dstoff *) msg sizeof_result_header_ext
-               (* len *) namelen ;
-    msg
+    String.concat String.empty [
+        of_int32_le @@ (Int32.of_int namelen) ;
+        last_filename ;
+    ]
+*)
+
 end

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -2,9 +2,9 @@
 (** for more details, see qubes-gui-common/include/qubes-gui-protocol.h *)
 
 let of_int32_le i =
-  assert(i < Int32.max_int);
-  let i = Int32.to_int i in
-  String.init 4 (fun p -> Char.chr ((i lsr (p*8)) land 0xff))
+  let b = Bytes.create 4 in
+  Bytes.set_int32_le b 0 i ;
+  Bytes.unsafe_to_string b
 
 (* String.get_* exixt since 4.13, this stub will be removed when the min
    Ocaml version will match *)

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -152,11 +152,13 @@ module GUI = struct
 
   let const_QUBES_MAIN_WINDOW = 1l
 
-  [%%cstruct
       type gui_protocol_version = {
-        version : uint32_t;
-      } [@@little_endian]
-  ]
+        version : int32;
+      }
+      let get_gui_protocol_version_version h = Bytes.get_int32_le h 0
+      let set_gui_protocol_version_version h v = Bytes.set_int32_le h 0 v
+      let sizeof_gui_protocol_version = 4
+ 
 
   (** struct msg_hdr *)
       type msg_header = {
@@ -188,13 +190,16 @@ module GUI = struct
 
   (** Dom0 -> VM, VM -> Dom0: MSG_CLIPBOARD_DATA:
       a normal header, followed by a uint8 array of size len *)
-  [%%cstruct
     type msg_clipboard_data = {
-      window_id : uint32_t [@big_endian];
-      len : uint32_t;
+      window_id : int32; (* [@big_endian]; *)
+      len : int32;
       (* followed by a uint8 array of size len *)
-    } [@@little_endian]
-  ]
+    }
+      let get_msg_clipboard_data_window_id h = Bytes.get_int32_be h 0
+      let set_msg_clipboard_data_window_id h v = Bytes.set_int32_be h 0 v
+      let get_msg_clipboard_data_len h = Bytes.get_int32_le h 4
+      let set_msg_clipboard_data_len h v = Bytes.set_int32_le h 4 v
+      let sizeof_msg_clipboard_data = 8
 
   (** VM -> Dom0 *)
       type msg_create = {
@@ -230,15 +235,25 @@ module GUI = struct
 
   (** Dom0 -> VM *)
   (* https://github.com/drinkcat/chroagh/commit/1d38c2e2422f97b6bf55580c9efc027ecf9f2721 *)
-  [%%cstruct
       type msg_keypress = {
-        ty    : uint32_t;
-        x     : uint32_t;
-        y     : uint32_t;
-        state : uint32_t; (** 1:down, 0:up *)
-        keycode : uint32_t;
-      } [@@little_endian]
-  ]
+        ty    : int32;
+        x     : int32;
+        y     : int32;
+        state : int32; (** 1:down, 0:up *)
+        keycode : int32;
+      }
+      let get_msg_keypress_ty h = Bytes.get_int32_le h 0
+      let set_msg_keypress_ty h v = Bytes.set_int32_le h 0 v
+      let get_msg_keypress_x h = Bytes.get_int32_le h 4
+      let set_msg_keypress_x h v = Bytes.set_int32_le h 4 v
+      let get_msg_keypress_y h = Bytes.get_int32_le h 8
+      let set_msg_keypress_y h v = Bytes.set_int32_le h 8 v
+      let get_msg_keypress_state h = Bytes.get_int32_le h 12
+      let set_msg_keypress_state h v = Bytes.set_int32_le h 12 v
+      let get_msg_keypress_keycode h = Bytes.get_int32_le h 16
+      let set_msg_keypress_keycode h v = Bytes.set_int32_le h 16 v
+      let sizeof_msg_keypress = 20
+
 
   type msg_button_t = {
    ty : int32 ; (* TODO make bool? ButtonPress / ButtonRelease*)
@@ -249,22 +264,31 @@ module GUI = struct
   }
 
   (** Dom0 -> VM, TODO seems to be mouse buttons? *)
-  [%%cstruct
    type msg_button = {
-     ty : uint32_t;
-     x : uint32_t;
-     y : uint32_t;
-     state : uint32_t;
-     button : uint32_t; (* TODO *)
-   } [@@little_endian]
-  ]
+     ty : int32;
+     x : int32;
+     y : int32;
+     state : int32;
+     button : int32; (* TODO *)
+   }
+   let get_msg_button_ty h = Bytes.get_int32_le h 0
+   let set_msg_button_ty h v = Bytes.set_int32_le h 0 v
+   let get_msg_button_x h = Bytes.get_int32_le h 4
+   let set_msg_button_x h v = Bytes.set_int32_le h 4 v
+   let get_msg_button_y h = Bytes.get_int32_le h 8
+   let set_msg_button_y h v = Bytes.set_int32_le h 8 v
+   let get_msg_button_state h = Bytes.get_int32_le h 12
+   let set_msg_button_state h v = Bytes.set_int32_le h 12 v
+   let get_msg_button_button h = Bytes.get_int32_le h 16
+   let set_msg_button_button h v = Bytes.set_int32_le h 16 v
+   let sizeof_msg_button = 20
 
-  let decode_msg_button cs : msg_button_t option =
-    Some ({ ty = get_msg_button_ty cs ;
-            x = get_msg_button_x cs ;
-            y = get_msg_button_y cs ;
-            state = get_msg_button_state cs ;
-            button = get_msg_button_button cs ;
+  let decode_msg_button b: msg_button_t option =
+    Some ({ ty = get_msg_button_ty b ;
+            x = get_msg_button_x b ;
+            y = get_msg_button_y b ;
+            state = get_msg_button_state b ;
+            button = get_msg_button_button b ;
       })
 
   (* dom0 -> VM, mouse / cursor movement *)
@@ -276,14 +300,21 @@ module GUI = struct
   }
 
   (** Dom0 -> VM, mouse / cursor motion event *)
-  [%%cstruct
       type msg_motion = {
-        x       : uint32_t;
-        y       : uint32_t;
-        state   : uint32_t;
-        is_hint : uint32_t;
-      } [@@little_endian]
-  ]
+        x       : int32;
+        y       : int32;
+        state   : int32;
+        is_hint : int32;
+      }
+      let get_msg_motion_x h = Bytes.get_int32_le h 0
+      let set_msg_motion_x h v = Bytes.set_int32_le h 0 v
+      let get_msg_motion_y h = Bytes.get_int32_le h 4
+      let set_msg_motion_y h v = Bytes.set_int32_le h 4 v
+      let get_msg_motion_state h = Bytes.get_int32_le h 8
+      let set_msg_motion_state h v = Bytes.set_int32_le h 8 v
+      let get_msg_motion_is_hint h = Bytes.get_int32_le h 12
+      let set_msg_motion_is_hint h v = Bytes.set_int32_le h 12 v
+      let sizeof_msg_motion = 16
 
   let decode_msg_motion cs : msg_motion_t option = (*TODO catch exceptions *)
   let i32 = fun f -> (f cs |> Int32.to_int) in
@@ -306,17 +337,30 @@ module GUI = struct
   }
 
   (** Dom0 -> VM, seems to fire when the mouse is moved over a window border *)
-  [%%cstruct
    type msg_crossing = {
-     ty : uint32_t;
-     x  : uint32_t;
-     y  : uint32_t;
-     state  : uint32_t;
-     mode   : uint32_t;
-     detail : uint32_t;
-     focus  : uint32_t;
-   } [@@little_endian]
-  ]
+     ty : int32;
+     x  : int32;
+     y  : int32;
+     state  : int32;
+     mode   : int32;
+     detail : int32;
+     focus  : int32;
+   }
+   let get_msg_crossing_ty h = Bytes.get_int32_le h 0
+   let set_msg_crossing_ty h v = Bytes.set_int32_le h 0 v
+   let get_msg_crossing_x h = Bytes.get_int32_le h 4
+   let set_msg_crossing_x h v = Bytes.set_int32_le h 4 v
+   let get_msg_crossing_y h = Bytes.get_int32_le h 8
+   let set_msg_crossing_y h v = Bytes.set_int32_le h 8 v
+   let get_msg_crossing_state h = Bytes.get_int32_le h 12
+   let set_msg_crossing_state h v = Bytes.set_int32_le h 12 v
+   let get_msg_crossing_mode h = Bytes.get_int32_le h 16
+   let set_msg_crossing_mode h v = Bytes.set_int32_le h 16 v
+   let get_msg_crossing_detail h = Bytes.get_int32_le h 20
+   let set_msg_crossing_detail h v = Bytes.set_int32_le h 20 v
+   let get_msg_crossing_focus h = Bytes.get_int32_le h 24
+   let set_msg_crossing_focus h v = Bytes.set_int32_le h 24 v
+   let sizeof_msg_crossing = 28
 
   let decode_msg_crossing cs  : msg_crossing_t option =
      (*TODO catch exceptions *)
@@ -391,13 +435,18 @@ module GUI = struct
   }
 
   (** Dom0 -> VM *)
-  [%%cstruct
       type msg_focus = {
-        ty     : uint32_t;
-        mode   : uint32_t;
-        detail : uint32_t;
-      } [@@little_endian]
-  ]
+        ty     : int32;
+        mode   : int32;
+        detail : int32;
+      }
+      let get_msg_focus_ty h = Bytes.get_int32_le h 0
+      let set_msg_focus_ty h v = Bytes.set_int32_le h 0 v
+      let get_msg_focus_mode h = Bytes.get_int32_le h 4
+      let set_msg_focus_mode h v = Bytes.set_int32_le h 4 v
+      let get_msg_focus_detail h = Bytes.get_int32_le h 8
+      let set_msg_focus_detail h v = Bytes.set_int32_le h 8 v
+      let sizeof_msg_focus = 12
 
   (* Dom0 -> VM *)
   [%%cstruct
@@ -407,17 +456,24 @@ module GUI = struct
   ]
 
   (** Dom0 -> VM: Xorg conf *)
-  [%%cstruct
       type xconf = {
-        w : uint32_t; (** width *)
-        h : uint32_t; (** height *)
-        depth : uint32_t; (** bits per pixel *)
-        mem : uint32_t; (* TODO seemingly unused , could be: MemBase baseaddress
+        w : int32; (** width *)
+        h : int32; (** height *)
+        depth : int32; (** bits per pixel *)
+        mem : int32; (* TODO seemingly unused , could be: MemBase baseaddress
     This optional entry specifies the memory base address of a graphics board's
     linear frame buffer. This entry is not used by many drivers, and it should
     only be specified if the driver-specific documentation recommends it. *)
-      } [@@little_endian]
-  ]
+      }
+      let get_xconf_w h = Bytes.get_int32_le h 0
+      let set_xconf_w h v = Bytes.set_int32_le h 0 v
+      let get_xconf_h h = Bytes.get_int32_le h 4
+      let set_xconf_h h v = Bytes.set_int32_le h 4 v
+      let get_xconf_depth h = Bytes.get_int32_le h 8
+      let set_xconf_depth h v = Bytes.set_int32_le h 8 v
+      let get_xconf_mem h = Bytes.get_int32_le h 12
+      let set_xconf_mem h v = Bytes.set_int32_le h 12 v
+      let sizeof_xconf = 16
 
   (* https://tronche.com/gui/x/icccm/sec-4.html#WM_TRANSIENT_FOR *)
 

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -20,8 +20,8 @@ module Qrexec = struct
       type peer_info = {
         version : int32;
       }
-      let get_peer_info_version h = Bytes.get_int32_le h 4
-      let set_peer_info_version h v = Bytes.set_int32_le h 4 v
+      let get_peer_info_version h = Bytes.get_int32_le h 0
+      let set_peer_info_version h v = Bytes.set_int32_le h 0 v
       let sizeof_peer_info = 4
 
       type exec_params = {
@@ -173,12 +173,15 @@ module GUI = struct
       let sizeof_msg_header = 12
 
   (** VM -> Dom0, Dom0 -> VM *)
-  [%%cstruct
       type msg_map_info = {
-        override_redirect : uint32_t;
-        transient_for     : uint32_t;
-      } [@@little_endian]
-  ]
+        override_redirect : int32;
+        transient_for     : int32;
+      }
+      let get_msg_map_info_override_redirect h = Bytes.get_int32_le h 0
+      let set_msg_map_info_override_redirect h v = Bytes.set_int32_le h 0 v
+      let get_msg_map_info_transient_for h = Bytes.get_int32_le h 4
+      let set_msg_map_info_transient_for h v = Bytes.set_int32_le h 4 v
+      let sizeof_msg_map_info = 8
 
   (** Dom0 -> VM, dom0 wants us to reply with a MSG_CLIPBOARD_DATA *)
   let sizeof_msg_clipboard_req = 0
@@ -194,16 +197,27 @@ module GUI = struct
   ]
 
   (** VM -> Dom0 *)
-  [%%cstruct
       type msg_create = {
-        x      : uint32_t; (* position of window, seems to be converted *)
-        y      : uint32_t;
-        width  : uint32_t;
-        height : uint32_t; (* from qubes src: "size of image" *)
-        parent : uint32_t;
-        override_redirect : uint32_t;
-      } [@@little_endian]
-  ]
+        x      : int32; (* position of window, seems to be converted *)
+        y      : int32;
+        width  : int32;
+        height : int32; (* from qubes src: "size of image" *)
+        parent : int32;
+        override_redirect : int32;
+      }
+      let get_msg_create_x h = Bytes.get_int32_le h 0
+      let set_msg_create_x h v = Bytes.set_int32_le h 0 v
+      let get_msg_create_y h = Bytes.get_int32_le h 4
+      let set_msg_create_y h v = Bytes.set_int32_le h 4 v
+      let get_msg_create_width h = Bytes.get_int32_le h 8
+      let set_msg_create_width h v = Bytes.set_int32_le h 8 v
+      let get_msg_create_height h = Bytes.get_int32_le h 12
+      let set_msg_create_height h v = Bytes.set_int32_le h 12 v
+      let get_msg_create_parent h = Bytes.get_int32_le h 16
+      let set_msg_create_parent h v = Bytes.set_int32_le h 16 v
+      let get_msg_create_override_redirect h = Bytes.get_int32_le h 20
+      let set_msg_create_override_redirect h v = Bytes.set_int32_le h 20 v
+      let sizeof_msg_create = 24
 
   type msg_keypress_t =
     {
@@ -318,15 +332,24 @@ module GUI = struct
   (** VM -> Dom0, Dom0 -> VM, note that when you send this you must read the
                           "corrected" MSG_CONFIGURE you get back and use those
                           values instead of your own *)
-  [%%cstruct
       type msg_configure = {
-        x      : uint32_t;
-        y      : uint32_t;
-        width  : uint32_t;
-        height : uint32_t;
-        override_redirect : uint32_t;
-      } [@@little_endian]
-    ]
+        x      : int32;
+        y      : int32;
+        width  : int32;
+        height : int32;
+        override_redirect : int32;
+      }
+      let get_msg_configure_x h = Bytes.get_int32_le h 0
+      let set_msg_configure_x h v = Bytes.set_int32_le h 0 v
+      let get_msg_configure_y h = Bytes.get_int32_le h 4
+      let set_msg_configure_y h v = Bytes.set_int32_le h 4 v
+      let get_msg_configure_width h = Bytes.get_int32_le h 8
+      let set_msg_configure_width h v = Bytes.set_int32_le h 8 v
+      let get_msg_configure_height h = Bytes.get_int32_le h 12
+      let set_msg_configure_height h v = Bytes.set_int32_le h 12 v
+      let get_msg_configure_override_redirect h = Bytes.get_int32_le h 16
+      let set_msg_configure_override_redirect h v = Bytes.set_int32_le h 16 v
+      let sizeof_msg_configure = 20
 
   type msg_configure_t = {
     x: int32;
@@ -344,15 +367,23 @@ module GUI = struct
             override_redirect = get_msg_configure_override_redirect cs ;
           } : msg_configure_t)
 
-  (** VM -> Dom0 *)
-  [%%cstruct
-   type msg_shmimage = {
-     x : uint32_t;
-     y : uint32_t;
-     width : uint32_t;
-     height: uint32_t;
-   } [@@little_endian]
-  ]
+    (** VM -> Dom0 *)
+      type msg_shmimage = {
+        x : int32;
+        y : int32;
+        width : int32;
+        height: int32;
+      }
+      let get_msg_shmimage_x h = Bytes.get_int32_le h 0
+      let set_msg_shmimage_x h v = Bytes.set_int32_le h 0 v
+      let get_msg_shmimage_y h = Bytes.get_int32_le h 4
+      let set_msg_shmimage_y h v = Bytes.set_int32_le h 4 v
+      let get_msg_shmimage_width h = Bytes.get_int32_le h 8
+      let set_msg_shmimage_width h v = Bytes.set_int32_le h 8 v
+      let get_msg_shmimage_height h = Bytes.get_int32_le h 12
+      let set_msg_shmimage_height h v = Bytes.set_int32_le h 12 v
+      let sizeof_msg_shmimage = 16
+
 
   type msg_focus_t = {
     mode : Cstruct.uint32;
@@ -407,19 +438,36 @@ module GUI = struct
 
   (** VM -> Dom0 *)
   (* https://standards.freedesktop.org/wm-spec/latest/ *)
-  [%%cstruct
-   type msg_window_hints = {
-     flags : uint32_t;
-     min_width : uint32_t;
-     min_height: uint32_t;
-     max_width: uint32_t;
-     max_height: uint32_t;
-     width_inc: uint32_t;
-     height_inc: uint32_t;
-     base_width: uint32_t;
-     base_height: uint32_t;
-   } [@@little_endian]
-  ]
+      type msg_window_hints = {
+        flags : int32;
+        min_width : int32;
+        min_height: int32;
+        max_width: int32;
+        max_height: int32;
+        width_inc: int32;
+        height_inc: int32;
+        base_width: int32;
+        base_height: int32;
+      }
+      let get_msg_window_hints_flags h = Bytes.get_int32_le h 0
+      let set_msg_window_hints_flags h v = Bytes.set_int32_le h 0 v
+      let get_msg_window_hints_min_width h = Bytes.get_int32_le h 4
+      let set_msg_window_hints_min_width h v = Bytes.set_int32_le h 4 v
+      let get_msg_window_hints_min_height h = Bytes.get_int32_le h 8
+      let set_msg_window_hints_min_height h v = Bytes.set_int32_le h 8 v
+      let get_msg_window_hints_max_width h = Bytes.get_int32_le h 12
+      let set_msg_window_hints_max_width h v = Bytes.set_int32_le h 12 v
+      let get_msg_window_hints_max_height h = Bytes.get_int32_le h 16
+      let set_msg_window_hints_max_height h v = Bytes.set_int32_le h 16 v
+      let get_msg_window_hints_width_inc h = Bytes.get_int32_le h 20
+      let set_msg_window_hints_width_inc h v = Bytes.set_int32_le h 20 v
+      let get_msg_window_hints_height_inc h = Bytes.get_int32_le h 24
+      let set_msg_window_hints_height_inc h v = Bytes.set_int32_le h 24 v
+      let get_msg_window_hints_base_width h = Bytes.get_int32_le h 28
+      let set_msg_window_hints_base_width h v = Bytes.set_int32_le h 28 v
+      let get_msg_window_hints_base_height h = Bytes.get_int32_le h 32
+      let set_msg_window_hints_base_height h v = Bytes.set_int32_le h 32 v
+      let sizeof_msg_window_hints = 36
 
   (** VM -> Dom0, Dom0 -> VM *)
   [%%cstruct
@@ -431,19 +479,33 @@ module GUI = struct
   ]
 
   (** VM -> Dom0 *)
-  [%%cstruct
       type shm_cmd = {
-        shmid     : uint32_t;
-        width     : uint32_t;
-        height    : uint32_t;
-        bpp       : uint32_t; (* bpp = bits per pixel *)
-        off       : uint32_t;
-        num_mfn   : uint32_t; (* number of pixels *)
-        domid     : uint32_t;
+        shmid     : int32;
+        width     : int32;
+        height    : int32;
+        bpp       : int32; (* bpp = bits per pixel *)
+        off       : int32;
+        num_mfn   : int32; (* number of pixels *)
+        domid     : int32;
         (* followed by a variable length buffer of pixels:*)
         (* uint32_t mfns[0]; *)
-      } [@@little_endian]
-  ]
+      }
+      let get_shm_cmd_shmid h = Bytes.get_int32_le h 0
+      let set_shm_cmd_shmid h v = Bytes.set_int32_le h 0 v
+      let get_shm_cmd_width h = Bytes.get_int32_le h 4
+      let set_shm_cmd_width h v = Bytes.set_int32_le h 4 v
+      let get_shm_cmd_height h = Bytes.get_int32_le h 8
+      let set_shm_cmd_height h v = Bytes.set_int32_le h 8 v
+      let get_shm_cmd_bpp h = Bytes.get_int32_le h 12
+      let set_shm_cmd_bpp h v = Bytes.set_int32_le h 12 v
+      let get_shm_cmd_off h = Bytes.get_int32_le h 16
+      let set_shm_cmd_off h v = Bytes.set_int32_le h 16 v
+      let get_shm_cmd_num_mfn h = Bytes.get_int32_le h 20
+      let set_shm_cmd_num_mfn h v = Bytes.set_int32_le h 20 v
+      let get_shm_cmd_domid h = Bytes.get_int32_le h 24
+      let set_shm_cmd_domid h v = Bytes.set_int32_le h 24 v
+      let sizeof_shm_cmd = 28
+      
 
   (** VM -> Dom0 *)
   [%%cstruct
@@ -531,7 +593,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
     (* n.b. must be followed by a MSG_SHMIMAGE to actually repaint *)
     let num_mfn = List.length mfns in
     let offset  = 0x0l in
-    let body = Cstruct.create (sizeof_shm_cmd + num_mfn*4) in
+    let body = Bytes.create (sizeof_shm_cmd + num_mfn*4) in
     set_shm_cmd_width   body width;
     set_shm_cmd_height  body height;
     set_shm_cmd_bpp     body 24l; (* bits per pixel *)
@@ -574,7 +636,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
 
   let make_msg_wmname ~window ~wmname =
     let body = Bytes.create sizeof_msg_wmname in
-    let()= Bytes.blit_from_string wmname 0 body 0
+    let()= Bytes.blit (Bytes.of_string wmname) 0 body 0
       (min String.(length wmname) sizeof_msg_wmname) ; (* length *) in
     make_with_header ~window ~ty:MSG_WMNAME body
 

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -6,6 +6,15 @@ let of_int32_le i =
   let i = Int32.to_int i in
   String.init 4 (fun p -> Char.chr ((i lsr (p*8)) land 0xff))
 
+(* String.get_* exixt since 4.13, this stub will be removed when the min
+   Ocaml version will match *)
+let get_int32_le s =
+  Bytes.get_int32_le (Bytes.unsafe_of_string s)
+let get_int32_be s =
+  Bytes.get_int32_be (Bytes.unsafe_of_string s)
+let get_uint8 s =
+  Bytes.get_uint8 (Bytes.unsafe_of_string s)
+
 module type FRAMING = sig
   val header_size : int
   val body_size_from_header : String.t -> int
@@ -16,16 +25,16 @@ module Qrexec = struct
         ty : int32;
         len : int32;
       }
-      let get_msg_header_ty h = String.get_int32_le h 0
+      let get_msg_header_ty h = get_int32_le h 0
       (* let set_msg_header_ty h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_header_len h = String.get_int32_le h 4
+      let get_msg_header_len h = get_int32_le h 4
       (* let set_msg_heade.r_len h vString= Bytes.set_int32_le h 4 v *)
       let sizeof_msg_header = 8
 
       type peer_info = {
         version : int32;
       }
-      let get_peer_info_version h = String.get_int32_le h 0
+      let get_peer_info_version h = get_int32_le h 0
       (* let set_peer_info_version h v = Bytes.set_int32_le h 0 v *)
       let sizeof_peer_info = 4
 
@@ -34,16 +43,16 @@ module Qrexec = struct
         connect_port : int32;
         (* rest of message is command line *)
       }
-      let get_exec_params_connect_domain h = String.get_int32_le h 0
+      let get_exec_params_connect_domain h = get_int32_le h 0
       (* let set_exec_params_connect_domain h v = Bytes.set_int32_le h 0 v *)
-      let get_exec_params_connect_port h = String.get_int32_le h 4
+      let get_exec_params_connect_port h = get_int32_le h 4
       (* let set_exec_params_connect_port h v = Bytes.set_int32_le h 4 v *)
       let sizeof_exec_params = 8
 
       type exit_status = {
         return_code : int32;
       }
-      let get_exit_status_return_code h = String.get_int32_le h 0
+      let get_exit_status_return_code h = get_int32_le h 0
       (* let set_exit_status_return_code h v = Bytes.set_int32_le h 0 v *)
       let sizeof_exit_status = 4
 
@@ -171,11 +180,11 @@ module GUI = struct
         window : int32;
         untrusted_len : int32;
       }
-      let get_msg_header_ty h = String.get_int32_le h 0
+      let get_msg_header_ty h = get_int32_le h 0
       (* let set._msg_header_ty h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_header_window h = String.get_int32_le h 4
+      let get_msg_header_window h = get_int32_le h 4
       (* let set_msg_header_window h v = Bytes.set_int32_le h 4 v *)
-      let get_msg_header_untrusted_len h = String.get_int32_le h 8
+      let get_msg_header_untrusted_len h = get_int32_le h 8
       (* let set_msg_header_untrusted_len h v = Bytes.set_int32_le h 8 v *)
       let sizeof_msg_header = 12
 
@@ -184,9 +193,9 @@ module GUI = struct
         override_redirect : int32;
         transient_for     : int32;
       }
-      let get_msg_map_info_override_redirect h = String.get_int32_le h 0
+      let get_msg_map_info_override_redirect h = get_int32_le h 0
       (* let set_msg_map_info_override_redirect h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_map_info_transient_for h = String.get_int32_le h 4
+      let get_msg_map_info_transient_for h = get_int32_le h 4
       (* let set_msg_map_info_transient_for h v = Bytes.set_int32_le h 4 v *)
       let sizeof_msg_map_info = 8
 
@@ -200,9 +209,9 @@ module GUI = struct
       len : int32;
       (* followed by a uint8 array of size len *)
     }
-      let get_msg_clipboard_data_window_id h = String.get_int32_be h 0
+      let get_msg_clipboard_data_window_id h = get_int32_be h 0
       (* let set_msg_clipboard_data_window_id h v = Bytes.set_int32_be h 0 v *)
-      let get_msg_clipboard_data_len h = String.get_int32_le h 4
+      let get_msg_clipboard_data_len h = get_int32_le h 4
       (* let set_msg_clipboard_data_len h v = Bytes.set_int32_le h 4 v *)
       let sizeof_msg_clipboard_data = 8
 
@@ -215,17 +224,17 @@ module GUI = struct
         parent : int32;
         override_redirect : int32;
       }
-      let get_msg_create_x h = String.get_int32_le h 0
+      let get_msg_create_x h = get_int32_le h 0
       (* let set_msg_create_x h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_create_y h = String.get_int32_le h 4
+      let get_msg_create_y h = get_int32_le h 4
       (* let set_msg_create_y h v = Bytes.set_int32_le h 4 v *)
-      let get_msg_create_width h = String.get_int32_le h 8
+      let get_msg_create_width h = get_int32_le h 8
       (* let set_msg_create_width h v = Bytes.set_int32_le h 8 v *)
-      let get_msg_create_height h = String.get_int32_le h 12
+      let get_msg_create_height h = get_int32_le h 12
       (* let set_msg_create_height h v = Bytes.set_int32_le h 12 v *)
-      let get_msg_create_parent h = String.get_int32_le h 16
+      let get_msg_create_parent h = get_int32_le h 16
       (* let set_msg_create_parent h v = Bytes.set_int32_le h 16 v *)
-      let get_msg_create_override_redirect h = String.get_int32_le h 20
+      let get_msg_create_override_redirect h = get_int32_le h 20
       (* let set_msg_create_override_redirect h v = Bytes.set_int32_le h 20 v *)
       let sizeof_msg_create = 24
 
@@ -249,15 +258,15 @@ module GUI = struct
         keycode : int32;
       }
 *)
-      let get_msg_keypress_ty h = String.get_int32_le h 0
+      let get_msg_keypress_ty h = get_int32_le h 0
       (* let set_msg_keypress_ty h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_keypress_x h = String.get_int32_le h 4
+      let get_msg_keypress_x h = get_int32_le h 4
       (* let set_msg_keypress_x h v = Bytes.set_int32_le h 4 v *)
-      let get_msg_keypress_y h = String.get_int32_le h 8
+      let get_msg_keypress_y h = get_int32_le h 8
       (* let set_msg_keypress_y h v = Bytes.set_int32_le h 8 v *)
-      let get_msg_keypress_state h = String.get_int32_le h 12
+      let get_msg_keypress_state h = get_int32_le h 12
       (* let set_msg_keypress_state h v = Bytes.set_int32_le h 12 v *)
-      let get_msg_keypress_keycode h = String.get_int32_le h 16
+      let get_msg_keypress_keycode h = get_int32_le h 16
       (* let set_msg_keypress_keycode h v = Bytes.set_int32_le h 16 v *)
       let sizeof_msg_keypress = 20
 
@@ -280,15 +289,15 @@ module GUI = struct
      button : int32; (* TODO *)
    }
 *)
-   let get_msg_button_ty h = String.get_int32_le h 0
+   let get_msg_button_ty h = get_int32_le h 0
    (* let set_msg_button_ty h v = Bytes.set_int32_le h 0 v *)
-   let get_msg_button_x h = String.get_int32_le h 4
+   let get_msg_button_x h = get_int32_le h 4
    (* let set_msg_button_x h v = Bytes.set_int32_le h 4 v *)
-   let get_msg_button_y h = String.get_int32_le h 8
+   let get_msg_button_y h = get_int32_le h 8
    (* let set_msg_button_y h v = Bytes.set_int32_le h 8 v *)
-   let get_msg_button_state h = String.get_int32_le h 12
+   let get_msg_button_state h = get_int32_le h 12
    (* let set_msg_button_state h v = Bytes.set_int32_le h 12 v *)
-   let get_msg_button_button h = String.get_int32_le h 16
+   let get_msg_button_button h = get_int32_le h 16
    (* let set_msg_button_button h v = Bytes.set_int32_le h 16 v *)
    let sizeof_msg_button = 20
 
@@ -308,10 +317,10 @@ module GUI = struct
     is_hint : int;
   }
 
-      let get_msg_motion_x h = String.get_int32_le h 0
-      let get_msg_motion_y h = String.get_int32_le h 4
-      let get_msg_motion_state h = String.get_int32_le h 8
-      let get_msg_motion_is_hint h = String.get_int32_le h 12
+      let get_msg_motion_x h = get_int32_le h 0
+      let get_msg_motion_y h = get_int32_le h 4
+      let get_msg_motion_state h = get_int32_le h 8
+      let get_msg_motion_is_hint h = get_int32_le h 12
       let sizeof_msg_motion = 16
 
   let decode_msg_motion str : msg_motion_t option = (*TODO catch exceptions *)
@@ -346,19 +355,19 @@ module GUI = struct
      focus  : int32;
    }
 *)
-   let get_msg_crossing_ty h = String.get_int32_le h 0
+   let get_msg_crossing_ty h = get_int32_le h 0
    (* let set_msg_crossing_ty h v = Bytes.set_int32_le h 0 v *)
-   let get_msg_crossing_x h = String.get_int32_le h 4
+   let get_msg_crossing_x h = get_int32_le h 4
    (* let set_msg_crossing_x h v = Bytes.set_int32_le h 4 v *)
-   let get_msg_crossing_y h = String.get_int32_le h 8
+   let get_msg_crossing_y h = get_int32_le h 8
    (* let set_msg_crossing_y h v = Bytes.set_int32_le h 8 v *)
-   let get_msg_crossing_state h = String.get_int32_le h 12
+   let get_msg_crossing_state h = get_int32_le h 12
    (* let set_msg_crossing_state h v = Bytes.set_int32_le h 12 v *)
-   let get_msg_crossing_mode h = String.get_int32_le h 16
+   let get_msg_crossing_mode h = get_int32_le h 16
    (* let set_msg_crossing_mode h v = Bytes.set_int32_le h 16 v *)
-   let get_msg_crossing_detail h = String.get_int32_le h 20
+   let get_msg_crossing_detail h = get_int32_le h 20
    (* let set_msg_crossing_detail h v = Bytes.set_int32_le h 20 v *)
-   let get_msg_crossing_focus h = String.get_int32_le h 24
+   let get_msg_crossing_focus h = get_int32_le h 24
    (* let set_msg_crossing_focus h v = Bytes.set_int32_le h 24 v *)
    let sizeof_msg_crossing = 28
 
@@ -392,15 +401,15 @@ module GUI = struct
         override_redirect : int32;
       }
 *)
-      let get_msg_configure_x h = String.get_int32_le h 0
+      let get_msg_configure_x h = get_int32_le h 0
       (* let set_msg_configure_x h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_configure_y h = String.get_int32_le h 4
+      let get_msg_configure_y h = get_int32_le h 4
       (* let set_msg_configure_y h v = Bytes.set_int32_le h 4 v *)
-      let get_msg_configure_width h = String.get_int32_le h 8
+      let get_msg_configure_width h = get_int32_le h 8
       (* let set_msg_configure_width h v = Bytes.set_int32_le h 8 v *)
-      let get_msg_configure_height h = String.get_int32_le h 12
+      let get_msg_configure_height h = get_int32_le h 12
       (* let set_msg_configure_height h v = Bytes.set_int32_le h 12 v *)
-      let get_msg_configure_override_redirect h = String.get_int32_le h 16
+      let get_msg_configure_override_redirect h = get_int32_le h 16
       (* let set_msg_configure_override_redirect h v = Bytes.set_int32_le h 16 v *)
       let sizeof_msg_configure = 20
 
@@ -419,13 +428,13 @@ module GUI = struct
         width : int32;
         height: int32;
       }
-      let get_msg_shmimage_x h = String.get_int32_le h 0
+      let get_msg_shmimage_x h = get_int32_le h 0
       (* let set_msg_shmimage_x h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_shmimage_y h = String.get_int32_le h 4
+      let get_msg_shmimage_y h = get_int32_le h 4
       (* let set_msg_shmimage_y h v = Bytes.set_int32_le h 4 v *)
-      let get_msg_shmimage_width h = String.get_int32_le h 8
+      let get_msg_shmimage_width h = get_int32_le h 8
       (* let set_msg_shmimage_width h v = Bytes.set_int32_le h 8 v *)
-      let get_msg_shmimage_height h = String.get_int32_le h 12
+      let get_msg_shmimage_height h = get_int32_le h 12
       (* let set_msg_shmimage_height h v = Bytes.set_int32_le h 12 v *)
       let sizeof_msg_shmimage = 16
 
@@ -441,11 +450,11 @@ module GUI = struct
         mode   : int32;
         detail : int32;
       }
-      let get_msg_focus_ty h = String.get_int32_le h 0
+      let get_msg_focus_ty h = get_int32_le h 0
       (* let set_msg_focus_ty h v = Bytes.set_int32_le h 0 v *)
-      let get_msg_focus_mode h = String.get_int32_le h 4
+      let get_msg_focus_mode h = get_int32_le h 4
       (* let set_msg_focus_mode h v = Bytes.set_int32_le h 4 v *)
-      let get_msg_focus_detail h = String.get_int32_le h 8
+      let get_msg_focus_detail h = get_int32_le h 8
       (* let set_msg_focus_detail h v = Bytes.set_int32_le h 8 v *)
       let sizeof_msg_focus = 12
 
@@ -467,13 +476,13 @@ module GUI = struct
     linear frame buffer. This entry is not used by many drivers, and it should
     only be specified if the driver-specific documentation recommends it. *)
       }
-      let get_xconf_w h = String.get_int32_le h 0
+      let get_xconf_w h = get_int32_le h 0
       (* let set_xconf_w h v = Bytes.set_int32_le h 0 v *)
-      let get_xconf_h h = String.get_int32_le h 4
+      let get_xconf_h h = get_int32_le h 4
       (* let set_xconf_h h v = Bytes.set_int32_le h 4 v *)
-      let get_xconf_depth h = String.get_int32_le h 8
+      let get_xconf_depth h = get_int32_le h 8
       (* let set_xconf_depth h v = Bytes.set_int32_le h 8 v *)
-      let get_xconf_mem h = String.get_int32_le h 12
+      let get_xconf_mem h = get_int32_le h 12
       (* let set_xconf_mem h v = Bytes.set_int32_le h 12 v *)
       let sizeof_xconf = 16
 
@@ -695,7 +704,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
 
   let make_with_header ~window ~ty ~body_len body =
     (** see qubes-gui-agent-linux/include/txrx.h:#define write_message *)
-    String.concat String.empty [
+    String.concat "" [
       of_int32_le (msg_type_to_int ty) ;
       of_int32_le window ;
       of_int32_le body_len ;
@@ -710,7 +719,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
                      + (XC_PAGE_SIZE-1)) / XC_PAGE_SIZE; *)
     let cmds = mfns |> List.mapi (fun i -> fun _ ->
         of_int32_le (Int32.of_int (sizeof_shm_cmd + i*4))) in
-    let body = String.concat String.empty @@ List.append [
+    let body = String.concat "" @@ List.append [
         of_int32_le width ;
         of_int32_le height ;
         of_int32_le 24l ; (* bits per pixel *)
@@ -726,7 +735,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
     make_with_header ~window ~ty:MSG_MFNDUMP ~body_len body
 
   let make_msg_shmimage ~window ~x ~y ~width ~height =
-    let body = String.concat String.empty [
+    let body = String.concat "" [
         of_int32_le x ;
         of_int32_le y ;
         of_int32_le width ;
@@ -736,7 +745,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
     make_with_header ~window ~ty:MSG_SHMIMAGE ~body_len body
 
   let make_msg_create ~window ~width ~height ~x ~y ~override_redirect ~parent =
-    let body = String.concat String.empty [
+    let body = String.concat "" [
         of_int32_le width ;
         of_int32_le height ;
         of_int32_le x ;
@@ -748,23 +757,23 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
     make_with_header ~window ~ty:MSG_CREATE ~body_len body
 
   let make_msg_map_info ~window ~override_redirect ~transient_for =
-    let body = String.concat String.empty [
-        of_int32_le override_redirect ;
-        of_int32_le transient_for ;
-    ] in
+    let body =
+        of_int32_le override_redirect ^
+        of_int32_le transient_for
+    in
     let body_len = Int32.of_int sizeof_msg_map_info in
     make_with_header ~window ~ty:MSG_MAP ~body_len body
 
   let make_msg_wmname ~window ~wmname =
-    let body = String.concat String.empty [
-        wmname ;
+    let body =
+        wmname ^
         String.make (sizeof_msg_wmname-String.(length wmname)) '\000' ; (* padding to sizeof_msg_wmname *)
-    ] in
+    in
     let body_len = Int32.of_int sizeof_msg_wmname in
     make_with_header ~window ~ty:MSG_WMNAME ~body_len body
 
   let make_msg_window_hints ~window ~width ~height =
-    let body = String.concat String.empty [
+    let body = String.concat "" [
         of_int32_le @@ Int32.(16 lor 32 |> of_int) ;
        (*^--  PMinSize | PMaxSize *)
         of_int32_le width ;  (* min width *)
@@ -776,7 +785,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
     make_with_header ~window ~ty:MSG_WINDOW_HINTS ~body_len body
 
   let make_msg_configure ~window ~x ~y ~width ~height =
-    let body = String.concat String.empty [
+    let body = String.concat "" [
         of_int32_le x ;
         of_int32_le y ; (* x and y are from qs->window_x and window_y*)
         of_int32_le width ;
@@ -867,18 +876,18 @@ module QubesDB = struct
         data_len  : int32;
         (* rest of message is data *)
       }
-      let get_msg_header_ty h = String.get_uint8 h 0
+      let get_msg_header_ty h = get_uint8 h 0
       (* let set_msg_header_ty h v = Bytes.set_uint8 h 0 v *)
       let get_msg_header_path h = String.sub h 1 64
       (* let set_msg_header_path h v = Bytes.blit_string v 0 h 1 (min (String.length v) 64) *)
-      let get_msg_header_data_len h = String.get_int32_le h 68
+      let get_msg_header_data_len h = get_int32_le h 68
       (* let set_msg_header_data_len h v = Bytes.set_int32_le h 68 v *)
       let sizeof_msg_header = 72
 
 
   let make_msg_header ~ty ~path ~data_len =
     assert(String.length path <= 64);
-    String.concat String.empty [
+    String.concat "" [
         String.make 1 (Char.chr (qdb_msg_to_int ty)) ; (* int8 *)
         path ;
         String.make (3+64-String.length path) '\000' ; (* padding=3 and max size of path=64 *)
@@ -944,10 +953,7 @@ module Rpc_filecopy = struct
 (*
   let make_result_header_ext last_filename =
     let namelen = Bytes.length last_filename in
-    String.concat String.empty [
-        of_int32_le @@ (Int32.of_int namelen) ;
-        last_filename ;
-    ]
+    of_int32_le @@ (Int32.of_int namelen) ^ last_filename
 *)
 
 end

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -868,7 +868,7 @@ module QubesDB = struct
 
 
   let make_msg_header ~ty ~path ~data_len =
-    let msg = Bytes.create sizeof_msg_header in
+    let msg = Bytes.make sizeof_msg_header '\x00' in
     set_msg_header_ty msg (qdb_msg_to_int ty);
     set_msg_header_path msg path;
     set_msg_header_data_len msg (Int32.of_int data_len);

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -17,7 +17,7 @@ let get_uint8 s =
 
 module type FRAMING = sig
   val header_size : int
-  val body_size_from_header : String.t -> int
+  val body_size_from_header : string -> int
 end
 
 module Qrexec = struct
@@ -57,9 +57,9 @@ module Qrexec = struct
       let sizeof_exit_status = 4
 
       type trigger_service_params = {
-        service_name : String.t; (* [@len 64]; *)
-        target_domain : String.t; (* [@len 32]; *)
-        request_id : String.t; (* [@len 32] *)
+        service_name : string; (* [@len 64]; *)
+        target_domain : string; (* [@len 32]; *)
+        request_id : string; (* [@len 32] *)
       }
       let get_trigger_service_params_service_name h = String.sub h 0 64
       (* let set_trigger_service_params_service_name v ofs h = Bytes.blit_string v 0 h ofs 64 *)
@@ -70,8 +70,8 @@ module Qrexec = struct
       let sizeof_trigger_service_params = 64+32+32
 
       type trigger_service_params3 = {
-        target_domain : String.t; (* [@len 64]; *)
-        request_id : String.t; (* [@len 32] *)
+        target_domain : string; (* [@len 64]; *)
+        request_id : string; (* [@len 32] *)
         (* rest of message is service name *)
       }
       let get_trigger_service_params3_target_domain h = String.sub h 0 64
@@ -79,7 +79,7 @@ module Qrexec = struct
       let get_trigger_service_params3_request_id h = String.sub h 64 32
       (* let set_trigger_service_params3_request_id v ofs h = Bytes.blit_string v 0 h (64+ofs) 32 *)
       let sizeof_trigger_service_params3 = 64+32
-    
+
   type msg_type =
     [ `Exec_cmdline
     | `Just_exec
@@ -172,7 +172,7 @@ module GUI = struct
       (* let get_gui_protocol_version_version h = Bytes.get_int32_le h 0 *)
       (* let set_gui_protocol_version_version h v = Bytes.set_int32_le h 0 v *)
       let sizeof_gui_protocol_version = 4
- 
+
 
   (** struct msg_hdr *)
       type msg_header = {
@@ -460,7 +460,7 @@ module GUI = struct
 
   (* Dom0 -> VM *)
       type msg_execute = {
-        cmd: String.t; (* uint8_t [@len 255]; *)
+        cmd: string; (* uint8_t [@len 255]; *)
       }
       (* let get_msg_execute_cmd h = h *)
       (* let set_msg_execute_cmd h v = Bytes.blit v 0 h 0 255 *)
@@ -490,7 +490,7 @@ module GUI = struct
 
   (** VM -> Dom0 *)
       type msg_wmname = {
-        data : String.t (*uint8_t  [@len 128];*) (* title of the window *)
+        data : string (*uint8_t  [@len 128];*) (* title of the window *)
       }
       (* let get_msg_wmname_data h = h *)
       (* let set_msg_wmname_data h v = Bytes.blit v 0 h 0 128 *)
@@ -499,7 +499,7 @@ module GUI = struct
   (** Dom0 -> VM *)
       type msg_keymap_notify = {
         (* this is a 256-bit bitmap of which keys should be enabled*)
-        keys : String.t (*uint8_t [@len 32];*)
+        keys : string (*uint8_t [@len 32];*)
       }
       (* let get_msg_keymap_notify_keys h = h *)
       (* let set_msg_keymap_notify_keys h v = Bytes.blit v 0 h 0 32 *)
@@ -577,12 +577,12 @@ module GUI = struct
       (* let get_shm_cmd_domid h = Bytes.get_int32_le h 24 *)
       (* let set_shm_cmd_domid h v = Bytes.set_int32_le h 24 v *)
       let sizeof_shm_cmd = 28
-      
+
 
   (** VM -> Dom0 *)
       type msg_wmclass = {
-        res_class : String.t ; (* uint8_t [@len 64]; *)
-        res_name : String.t ;(* uint8_t [@len 64]; *)
+        res_class : string ; (* uint8_t [@len 64]; *)
+        res_name : string ;(* uint8_t [@len 64]; *)
       }
       (* let get_msg_wmclass_res_class h = Bytes.sub h 0 64 *)
       (* let set_msg_wmclass_res_class h v = Bytes.blit v 0 h 0 64 *)
@@ -678,7 +678,7 @@ module GUI = struct
     | 128l -> Some MSG_FOCUS
     (*| 124l -> Some MSG_RESIZE - DEPRECATED; NOT IMPLEMENTED *)
     | 130l -> Some MSG_CREATE         (*[@id 130_l]*) (* 0x82_l *)
-    | 131l -> Some MSG_DESTROY 
+    | 131l -> Some MSG_DESTROY
     | 132l -> Some MSG_MAP
     | 133l -> Some MSG_UNMAP
     | 134l -> Some MSG_CONFIGURE
@@ -871,8 +871,8 @@ module QubesDB = struct
 
       type msg_header = {
         ty        : int;
-        path      : String.t; (* [@len 64]; *)
-        padding   : String.t; (* [@len 3]; *)
+        path      : string; (* [@len 64]; *)
+        padding   : string; (* [@len 3]; *)
         data_len  : int32;
         (* rest of message is data *)
       }

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -687,20 +687,26 @@ module QubesDB = struct
         [@@uint8_t]
   ]
 
-  [%%cstruct
       type msg_header = {
-        ty        : uint8_t;
-        path      : uint8_t [@len 64];
-        padding   : uint8_t [@len 3];
-        data_len  : uint32_t;
+        ty        : int;
+        path      : Bytes.t; (* [@len 64]; *)
+        padding   : Bytes.t; (* [@len 3]; *)
+        data_len  : int32;
         (* rest of message is data *)
-      } [@@little_endian]
-  ]
+      }
+      let get_msg_header_ty h = Bytes.get_uint8 h 0
+      let set_msg_header_ty h v = Bytes.set_uint8 h 0 v
+      let get_msg_header_path h = Bytes.sub h 1 64
+      let set_msg_header_path h v = Bytes.blit v 0 h 1 64
+      let get_msg_header_data_len h = Bytes.get_int32_le h 68
+      let set_msg_header_data_len h v = Bytes.set_int32_le h 68 v
+      let sizeof_msg_header = 72
+
 
   let make_msg_header ~ty ~path ~data_len =
-    let msg = Cstruct.create sizeof_msg_header in
+    let msg = Bytes.create sizeof_msg_header in
     set_msg_header_ty msg (qdb_msg_to_int ty);
-    Cstruct.blit_from_string path 0 (get_msg_header_path msg) 0 (String.length path);
+    Bytes.blit (Bytes.of_string path) 0 (get_msg_header_path msg) 0 (String.length path);
     set_msg_header_data_len msg (Int32.of_int data_len);
     msg
 

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -153,10 +153,10 @@ let connect ~domid () =
   (* qubesgui_init_connection *)
   let version = Formats.of_int32_le qubes_gui_protocol_version_linux in
   QV.send qv [version] >>= function
-  | `Eof -> Lwt.fail_with "End-of-file sending protocol version"
+  | `Eof -> failwith "End-of-file sending protocol version"
   | `Ok () ->
   QV.recv_fixed qv sizeof_xconf >>= function
-  | `Eof -> Lwt.fail_with "End-of-file getting X configuration"
+  | `Eof -> failwith "End-of-file getting X configuration"
   | `Ok conf ->
   let screen_w = get_xconf_w conf in
   let screen_h = get_xconf_h conf in

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -24,7 +24,7 @@ type event =
   | Focus of msg_focus_t
   | Motion of msg_motion_t
   | Clipboard_request
-  | Clipboard_data of Cstruct.t
+  | Clipboard_data of Bytes.t
   | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy
@@ -37,7 +37,7 @@ let pp_event fmt event =
   | UNIT () -> pf() "UNIT"
   | Button _ -> pf() "Button"
   | Clipboard_request -> pf() "Clipboard_request"
-  | Clipboard_data cs -> pf() "Clipboard_data: %S" (Cstruct.to_string cs)
+  | Clipboard_data b -> pf() "Clipboard_data: %S" (Bytes.to_string b)
   | Configure x -> pf() "Configure: @[x=%ld;@ y=%ld;@ width=%ld;@ height=%ld@]"
                      x.x x.y x.width x.height
   | Focus {mode;detail} -> pf() "Focus mode: %ld detail: %ld" mode detail
@@ -74,22 +74,24 @@ let decode_FOCUS buf =
   } in
   Focus focus
 
-let decode_MSG_CLOSE buf =
-  Log.warn (fun f -> f "Event: CLOSE: %a" Cstruct.hexdump_pp buf) ;
+let decode_MSG_CLOSE _buf =
+  Log.warn (fun f -> f "Event: CLOSE: ") ;
+(* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) buf ;*)
   Window_close
 
 let decode_CLIPBOARD_DATA buf =
-  Log.warn (fun f -> f "Event: CLIPBOARD_DATA: %a" Cstruct.hexdump_pp buf);
+  Log.warn (fun f -> f "Event: CLIPBOARD_DATA:");
+(* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) buf ;*)
   let len = get_msg_clipboard_data_len buf |> Int32.to_int in
   match
     Int32.compare (get_msg_clipboard_data_len buf) 0l = -1
-    || Cstruct.length buf + sizeof_msg_clipboard_data <> len with
+    || Bytes.length buf + sizeof_msg_clipboard_data <> len with
   | true ->
     Logs.warn (fun m -> m "Got invalid CLIPBOARD_DATA msg from dom0");
     UNIT ()
   | false ->
     (* TODO expose the window id of the recipient window *)
-    Clipboard_data (Cstruct.sub buf sizeof_msg_clipboard_data len)
+    Clipboard_data (Bytes.sub buf sizeof_msg_clipboard_data len)
 
 let int32_of_window (w : window) : int32 = w.no
 
@@ -100,7 +102,8 @@ let decode_MSG_MOTION buf =
                  m.x m.y m.state m.is_hint);
     Motion m
   | None ->
-    Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: %a" Cstruct.hexdump_pp buf);
+    Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: ");
+        (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) buf ;*)
     UNIT ()
 
 let decode_CONFIGURE buf =
@@ -152,7 +155,7 @@ let connect ~domid () =
   Log.info (fun f -> f "waiting for client...");
   QV.server ~domid ~port:gui_agent_port () >>= fun qv ->
   (* qubesgui_init_connection *)
-  let version = Cstruct.create sizeof_gui_protocol_version in
+  let version = Bytes.create sizeof_gui_protocol_version in
   set_gui_protocol_version_version version qubes_gui_protocol_version_linux;
   QV.send qv [version] >>= function
   | `Eof -> Lwt.fail_with "End-of-file sending protocol version"
@@ -196,14 +199,15 @@ let rec listen t () =
          | MSG_CLOSE as msg)
     when (match msg_type_size msg with Some x -> x <> msg_len | None -> true) ->
     Log.warn (fun f -> f "BUG: expected_size [%d] <> msg_len [%d] for fixed-\
-                          size msg! msg_header: %a@ Received raw buffer:: %a"
+                          size msg! msg_header: @ Received raw buffer:: "
                  (match msg_type_size msg with Some x -> x | None -> -1)
-                 msg_len
-                 Cstruct.hexdump_pp msg_header
-                 Cstruct.hexdump_pp msg_buf) ;
+                 msg_len) ;
+    (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_header ;*)
+    (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
     UNIT()
   | Some MSG_MAP ->
-    Log.warn (fun f -> f "Event: MAP: %a" Cstruct.hexdump_pp msg_buf) ;
+    Log.warn (fun f -> f "Event: MAP: ");
+    (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
     UNIT()
   | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
   | Some MSG_FOCUS -> decode_FOCUS msg_buf
@@ -213,28 +217,30 @@ let rec listen t () =
     Clipboard_request
   | Some MSG_CROSSING -> begin match decode_msg_crossing msg_buf with
       | Some event -> Window_crossing event
-      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding %a"
-                             Cstruct.hexdump_pp msg_buf)
+      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding ")
+             (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
               ; UNIT ()
       end
   | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
   | Some MSG_BUTTON -> begin match decode_msg_button msg_buf with
       | Some button_event -> Button button_event
-      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding %a"
-                             Cstruct.hexdump_pp msg_buf)
+      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding ")
+             (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
         ; UNIT ()
       end
   | Some MSG_KEYMAP_NOTIFY ->
     (* Synchronize the keyboard state (key pressed/released) with dom0 *)
-    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %S"
-      Cstruct.(to_string msg_buf)) ;
+    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: ");
+             (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
     UNIT()
   | Some MSG_WINDOW_FLAGS ->
-    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %S" Cstruct.(to_string msg_buf))
-      ; UNIT ()
+    Log.warn (fun f -> f "Event: WINDOW_FLAGS: ")
+      ;
+             (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
+      UNIT ()
   | Some MSG_CONFIGURE ->
-    Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a"
-                 Cstruct.hexdump_pp msg_buf) ;
+    Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): ");
+             (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
     (* TODO here we should ACK to Qubes that we accept the new dimensions,
             atm this is the responsibility of the user: *)
     decode_CONFIGURE msg_buf
@@ -251,12 +257,13 @@ let rec listen t () =
     (* Handle messages that are appvm->dom0 and thus dom0 is not supposed
        to send to the VM: *)
     Log.warn (fun f ->
-        f "UNEXPECTED message received. Data: %a"
-          Cstruct.hexdump_pp msg_buf); UNIT()
+        f "UNEXPECTED message received. Data:");
+        (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
+        UNIT()
   | None ->
-    Log.warn (fun f -> f "Unexpected data with unknown type: [%a] %aa"
-                 Cstruct.hexdump_pp msg_header
-                 Cstruct.hexdump_pp msg_buf) ;
+    Log.warn (fun f -> f "Unexpected data with unknown type: [] a") ;
+        (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_header ;*)
+        (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) msg_buf ;*)
     UNIT()
   end
   >>= fun () -> listen t ()

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -107,8 +107,8 @@ let decode_CONFIGURE buf =
   match decode_msg_configure buf with
   | Some m -> Configure m
   | None ->
-    Log.warn (fun f -> f "failed decoding CONFIGURE message from dom0: %a"
-                 Cstruct.hexdump_pp buf) ;
+    Log.warn (fun f -> f "failed decoding CONFIGURE message from dom0: ") ;
+    (* Bytes.iter (fun c -> Printf.printf ("%02x ") (char_to_int c)) buf ;*)
     UNIT ()
 
 let recv_event (window:window) =

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -24,7 +24,7 @@ type event =
   | Focus of msg_focus_t
   | Motion of msg_motion_t
   | Clipboard_request
-  | Clipboard_data of String.t
+  | Clipboard_data of string
   | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -201,7 +201,7 @@ let rec listen t () =
                  (Ohex.pp ()) msg_buf) ;
     UNIT()
   | Some MSG_MAP ->
-    Log.warn (fun f -> f "Event: MAP: %s" (Ohex.encode msg_buf));
+    Log.warn (fun f -> f "Event: MAP: %a" (Ohex.pp ()) msg_buf);
     UNIT()
   | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
   | Some MSG_FOCUS -> decode_FOCUS msg_buf

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -75,11 +75,11 @@ let decode_FOCUS buf =
   Focus focus
 
 let decode_MSG_CLOSE buf =
-  Log.warn (fun f -> f "Event: CLOSE: %a" (Ohex.pp ()) buf);
+  Log.warn (fun f -> f "Event: CLOSE: %a" Ohex.pp buf);
   Window_close
 
 let decode_CLIPBOARD_DATA buf =
-  Log.warn (fun f -> f "Event: CLIPBOARD_DATA: %a" (Ohex.pp ()) buf);
+  Log.warn (fun f -> f "Event: CLIPBOARD_DATA: %a" Ohex.pp buf);
   let len = get_msg_clipboard_data_len buf |> Int32.to_int in
   match
     Int32.compare (get_msg_clipboard_data_len buf) 0l = -1
@@ -100,14 +100,14 @@ let decode_MSG_MOTION buf =
                  m.x m.y m.state m.is_hint);
     Motion m
   | None ->
-    Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: %a" (Ohex.pp ()) buf);
+    Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: %a" Ohex.pp buf);
     UNIT ()
 
 let decode_CONFIGURE buf =
   match decode_msg_configure buf with
   | Some m -> Configure m
   | None ->
-    Log.warn (fun f -> f "failed decoding CONFIGURE message from dom0: %a" (Ohex.pp ()) buf);
+    Log.warn (fun f -> f "failed decoding CONFIGURE message from dom0: %a" Ohex.pp buf);
     UNIT ()
 
 let recv_event (window:window) =
@@ -197,11 +197,11 @@ let rec listen t () =
                           size msg! msg_header: %a@ Received raw buffer:: %a"
                  (match msg_type_size msg with Some x -> x | None -> -1)
                  msg_len
-                 (Ohex.pp ()) msg_header
-                 (Ohex.pp ()) msg_buf) ;
+                 Ohex.pp msg_header
+                 Ohex.pp msg_buf) ;
     UNIT()
   | Some MSG_MAP ->
-    Log.warn (fun f -> f "Event: MAP: %a" (Ohex.pp ()) msg_buf);
+    Log.warn (fun f -> f "Event: MAP: %a" Ohex.pp msg_buf);
     UNIT()
   | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
   | Some MSG_FOCUS -> decode_FOCUS msg_buf
@@ -211,25 +211,25 @@ let rec listen t () =
     Clipboard_request
   | Some MSG_CROSSING -> begin match decode_msg_crossing msg_buf with
       | Some event -> Window_crossing event
-      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding %a" (Ohex.pp ()) msg_buf)
+      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding %a" Ohex.pp msg_buf)
               ; UNIT ()
       end
   | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
   | Some MSG_BUTTON -> begin match decode_msg_button msg_buf with
       | Some button_event -> Button button_event
-      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding %a" (Ohex.pp ()) msg_buf)
+      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding %a" Ohex.pp msg_buf)
         ; UNIT ()
       end
   | Some MSG_KEYMAP_NOTIFY ->
     (* Synchronize the keyboard state (key pressed/released) with dom0 *)
-    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %a" (Ohex.pp ()) msg_buf);
+    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %a" Ohex.pp msg_buf);
     UNIT()
   | Some MSG_WINDOW_FLAGS ->
-    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %a" (Ohex.pp ()) msg_buf)
+    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %a" Ohex.pp msg_buf)
       ;
       UNIT ()
   | Some MSG_CONFIGURE ->
-    Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a" (Ohex.pp ()) msg_buf);
+    Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a" Ohex.pp msg_buf);
     (* TODO here we should ACK to Qubes that we accept the new dimensions,
             atm this is the responsibility of the user: *)
     decode_CONFIGURE msg_buf
@@ -246,12 +246,12 @@ let rec listen t () =
     (* Handle messages that are appvm->dom0 and thus dom0 is not supposed
        to send to the VM: *)
     Log.warn (fun f ->
-        f "UNEXPECTED message received. Data: %a" (Ohex.pp ()) msg_buf);
+        f "UNEXPECTED message received. Data: %a" Ohex.pp msg_buf);
         UNIT()
   | None ->
     Log.warn (fun f -> f "Unexpected data with unknown type: [%a] a %a"
-        (Ohex.pp ()) msg_header
-        (Ohex.pp ()) msg_buf) ;
+        Ohex.pp msg_header
+        Ohex.pp msg_buf) ;
     UNIT()
   end
   >>= fun () -> listen t ()

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -24,7 +24,7 @@ type event =
   | Focus of msg_focus_t
   | Motion of msg_motion_t
   | Clipboard_request
-  | Clipboard_data of Bytes.t
+  | Clipboard_data of String.t
   | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy
@@ -37,7 +37,7 @@ let pp_event fmt event =
   | UNIT () -> pf() "UNIT"
   | Button _ -> pf() "Button"
   | Clipboard_request -> pf() "Clipboard_request"
-  | Clipboard_data b -> pf() "Clipboard_data: %S" (Bytes.to_string b)
+  | Clipboard_data str -> pf() "Clipboard_data: %S" str
   | Configure x -> pf() "Configure: @[x=%ld;@ y=%ld;@ width=%ld;@ height=%ld@]"
                      x.x x.y x.width x.height
   | Focus {mode;detail} -> pf() "Focus mode: %ld detail: %ld" mode detail
@@ -75,21 +75,21 @@ let decode_FOCUS buf =
   Focus focus
 
 let decode_MSG_CLOSE buf =
-  Log.warn (fun f -> f "Event: CLOSE: %a" (Ohex.pp ()) (Bytes.unsafe_to_string buf));
+  Log.warn (fun f -> f "Event: CLOSE: %a" (Ohex.pp ()) buf);
   Window_close
 
 let decode_CLIPBOARD_DATA buf =
-  Log.warn (fun f -> f "Event: CLIPBOARD_DATA: %a" (Ohex.pp ()) (Bytes.unsafe_to_string buf));
+  Log.warn (fun f -> f "Event: CLIPBOARD_DATA: %a" (Ohex.pp ()) buf);
   let len = get_msg_clipboard_data_len buf |> Int32.to_int in
   match
     Int32.compare (get_msg_clipboard_data_len buf) 0l = -1
-    || Bytes.length buf + sizeof_msg_clipboard_data <> len with
+    || String.length buf + sizeof_msg_clipboard_data <> len with
   | true ->
     Logs.warn (fun m -> m "Got invalid CLIPBOARD_DATA msg from dom0");
     UNIT ()
   | false ->
     (* TODO expose the window id of the recipient window *)
-    Clipboard_data (Bytes.sub buf sizeof_msg_clipboard_data len)
+    Clipboard_data (String.sub buf sizeof_msg_clipboard_data len)
 
 let int32_of_window (w : window) : int32 = w.no
 
@@ -100,14 +100,14 @@ let decode_MSG_MOTION buf =
                  m.x m.y m.state m.is_hint);
     Motion m
   | None ->
-    Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: %a" (Ohex.pp ()) (Bytes.unsafe_to_string buf));
+    Log.warn (fun f -> f "attempted to decode a motion event, but we were not successful: %a" (Ohex.pp ()) buf);
     UNIT ()
 
 let decode_CONFIGURE buf =
   match decode_msg_configure buf with
   | Some m -> Configure m
   | None ->
-    Log.warn (fun f -> f "failed decoding CONFIGURE message from dom0: %a" (Ohex.pp ()) (Bytes.unsafe_to_string buf));
+    Log.warn (fun f -> f "failed decoding CONFIGURE message from dom0: %a" (Ohex.pp ()) buf);
     UNIT ()
 
 let recv_event (window:window) =
@@ -151,8 +151,7 @@ let connect ~domid () =
   Log.info (fun f -> f "waiting for client...");
   QV.server ~domid ~port:gui_agent_port () >>= fun qv ->
   (* qubesgui_init_connection *)
-  let version = Bytes.create sizeof_gui_protocol_version in
-  set_gui_protocol_version_version version qubes_gui_protocol_version_linux;
+  let version = Formats.of_int32_le qubes_gui_protocol_version_linux in
   QV.send qv [version] >>= function
   | `Eof -> Lwt.fail_with "End-of-file sending protocol version"
   | `Ok () ->
@@ -198,11 +197,11 @@ let rec listen t () =
                           size msg! msg_header: %a@ Received raw buffer:: %a"
                  (match msg_type_size msg with Some x -> x | None -> -1)
                  msg_len
-                 (Ohex.pp ()) (Bytes.unsafe_to_string msg_header)
-                 (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf)) ;
+                 (Ohex.pp ()) msg_header
+                 (Ohex.pp ()) msg_buf) ;
     UNIT()
   | Some MSG_MAP ->
-    Log.warn (fun f -> f "Event: MAP: %s" (Ohex.encode (Bytes.to_string msg_buf)));
+    Log.warn (fun f -> f "Event: MAP: %s" (Ohex.encode msg_buf));
     UNIT()
   | Some MSG_KEYPRESS -> decode_KEYPRESS msg_buf
   | Some MSG_FOCUS -> decode_FOCUS msg_buf
@@ -212,25 +211,25 @@ let rec listen t () =
     Clipboard_request
   | Some MSG_CROSSING -> begin match decode_msg_crossing msg_buf with
       | Some event -> Window_crossing event
-      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding %a" (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf))
+      | None -> Log.warn (fun m -> m "Invalid MSG_CROSSING during decoding %a" (Ohex.pp ()) msg_buf)
               ; UNIT ()
       end
   | Some MSG_CLOSE -> decode_MSG_CLOSE msg_buf
   | Some MSG_BUTTON -> begin match decode_msg_button msg_buf with
       | Some button_event -> Button button_event
-      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding %a" (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf))
+      | None -> Log.warn (fun m -> m "Invalid MSG_BUTTON decoding %a" (Ohex.pp ()) msg_buf)
         ; UNIT ()
       end
   | Some MSG_KEYMAP_NOTIFY ->
     (* Synchronize the keyboard state (key pressed/released) with dom0 *)
-    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %a" (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf));
+    Log.warn (fun f -> f "Event: KEYMAP_NOTIFY: %a" (Ohex.pp ()) msg_buf);
     UNIT()
   | Some MSG_WINDOW_FLAGS ->
-    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %a" (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf))
+    Log.warn (fun f -> f "Event: WINDOW_FLAGS: %a" (Ohex.pp ()) msg_buf)
       ;
       UNIT ()
   | Some MSG_CONFIGURE ->
-    Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a" (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf));
+    Log.warn (fun f -> f "Event: CONFIGURE (should reply with this): %a" (Ohex.pp ()) msg_buf);
     (* TODO here we should ACK to Qubes that we accept the new dimensions,
             atm this is the responsibility of the user: *)
     decode_CONFIGURE msg_buf
@@ -247,12 +246,12 @@ let rec listen t () =
     (* Handle messages that are appvm->dom0 and thus dom0 is not supposed
        to send to the VM: *)
     Log.warn (fun f ->
-        f "UNEXPECTED message received. Data: %a" (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf));
+        f "UNEXPECTED message received. Data: %a" (Ohex.pp ()) msg_buf);
         UNIT()
   | None ->
     Log.warn (fun f -> f "Unexpected data with unknown type: [%a] a %a"
-        (Ohex.pp ()) (Bytes.unsafe_to_string msg_header)
-        (Ohex.pp ()) (Bytes.unsafe_to_string msg_buf)) ;
+        (Ohex.pp ()) msg_header
+        (Ohex.pp ()) msg_buf) ;
     UNIT()
   end
   >>= fun () -> listen t ()

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -15,7 +15,7 @@ type event =
   | Focus of msg_focus_t
   | Motion of msg_motion_t
   | Clipboard_request
-  | Clipboard_data of Cstruct.t
+  | Clipboard_data of Bytes.t
   | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -45,7 +45,7 @@ val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
     coordinates [x]*[y] (relative to the screen's [0,0]).
 *)
 
-val send : t -> Cstruct.t list -> unit S.or_eof Lwt.t
+val send : t -> Bytes.t list -> unit S.or_eof Lwt.t
 (** [send t messages] synchronously sends [messages] to the Qubes GUId
                       using [t]'s established vchan *)
 

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -15,7 +15,7 @@ type event =
   | Focus of msg_focus_t
   | Motion of msg_motion_t
   | Clipboard_request
-  | Clipboard_data of Bytes.t
+  | Clipboard_data of String.t
   | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy
@@ -45,7 +45,7 @@ val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
     coordinates [x]*[y] (relative to the screen's [0,0]).
 *)
 
-val send : t -> Bytes.t list -> unit S.or_eof Lwt.t
+val send : t -> String.t list -> unit S.or_eof Lwt.t
 (** [send t messages] synchronously sends [messages] to the Qubes GUId
                       using [t]'s established vchan *)
 

--- a/lib/gUI.mli
+++ b/lib/gUI.mli
@@ -15,7 +15,7 @@ type event =
   | Focus of msg_focus_t
   | Motion of msg_motion_t
   | Clipboard_request
-  | Clipboard_data of String.t
+  | Clipboard_data of string
   | Configure of Formats.GUI.msg_configure_t
   | Window_crossing of msg_crossing_t
   | Window_destroy
@@ -45,7 +45,7 @@ val create_window : ?parent:window_id -> x:Cstruct.uint32 -> y:Cstruct.uint32 ->
     coordinates [x]*[y] (relative to the screen's [0,0]).
 *)
 
-val send : t -> String.t list -> unit S.or_eof Lwt.t
+val send : t -> string list -> unit S.or_eof Lwt.t
 (** [send t messages] synchronously sends [messages] to the Qubes GUId
                       using [t]'s established vchan *)
 

--- a/lib/ipv4/dune
+++ b/lib/ipv4/dune
@@ -1,5 +1,5 @@
 (library
  (name qubesdb_ipv4)
  (public_name mirage-qubes-ipv4)
- (libraries cstruct lwt logs tcpip tcpip.ipv4 ipaddr
+ (libraries lwt tcpip tcpip.ipv4 ipaddr
    arp ethernet mirage-qubes mirage-clock mirage-random))

--- a/lib/ipv4/qubesdb_ipv4.ml
+++ b/lib/ipv4/qubesdb_ipv4.ml
@@ -20,5 +20,5 @@ module Make
       let cidr = Ipaddr.V4.Prefix.make 32 ip in
       connect ~cidr ?gateway ethif arp
     | Error (`Msg m) ->
-      Lwt.fail_with ("couldn't get ip configuration from qubesdb: " ^ m)
+      failwith ("couldn't get ip configuration from qubesdb: " ^ m)
 end

--- a/lib/msg_chan.ml
+++ b/lib/msg_chan.ml
@@ -18,20 +18,20 @@ module Make (F : Formats.FRAMING) = struct
   type t = {
     domid : int;
     vchan : Vchan_xen.flow;
-    mutable buffer : Cstruct.t;
+    mutable buffer : Bytes.t;
     read_lock : Lwt_mutex.t;
     write_lock : Lwt_mutex.t;
   }
 
   let rec read_exactly t size =
-    let avail = Cstruct.length t.buffer in
+    let avail = Bytes.length t.buffer in
     if avail >= size then (
-      let retval = Cstruct.sub t.buffer 0 size in
-      t.buffer <- Cstruct.shift t.buffer size;
+      let retval = Bytes.sub t.buffer 0 size in
+      Bytes.blit t.buffer size t.buffer 0 (avail-size);
       return (`Ok retval)
     ) else (
       Vchan_xen.read t.vchan >|= unwrap_read >>!= fun buf ->
-      t.buffer <- Cstruct.append t.buffer buf;
+      t.buffer <- Bytes.cat t.buffer (Cstruct.to_bytes buf);
       read_exactly t size
     )
 
@@ -48,20 +48,22 @@ module Make (F : Formats.FRAMING) = struct
       return (`Ok body)
     )
 
-  let recv_raw t : Cstruct.t S.or_eof Lwt.t =
+  let recv_raw t : Bytes.t S.or_eof Lwt.t =
     Lwt_mutex.with_lock t.read_lock @@ fun () ->
-    if Cstruct.length t.buffer > 0 then (
+    if Bytes.length t.buffer > 0 then (
       let data = t.buffer in
-      t.buffer <- Cstruct.create 0;
+      t.buffer <- Bytes.empty;
       return (`Ok data)
     ) else (
       Vchan_xen.read t.vchan >|= unwrap_read >>!= fun result ->
-      return (`Ok result)
+      let data = Cstruct.to_bytes result in
+      return (`Ok data)
     )
 
-  let send t (buffers : Cstruct.t list) : unit S.or_eof Lwt.t =
+  let send t (buffers : Bytes.t list) : unit S.or_eof Lwt.t =
     Lwt_mutex.with_lock t.write_lock (fun () ->
-      Vchan_xen.writev t.vchan buffers >>= function
+      let c = Bytes.concat Bytes.empty buffers in
+      Vchan_xen.writev t.vchan [Cstruct.of_bytes c] >>= function
       | Error `Closed -> return `Eof
       | Error e -> fail (Failure (Format.asprintf "%a" Vchan_xen.pp_write_error e))
       | Ok _ -> return @@ `Ok ()
@@ -71,7 +73,7 @@ module Make (F : Formats.FRAMING) = struct
     Vchan_xen.server ~domid ~port () >|= fun vchan -> {
       vchan;
       domid;
-      buffer = Cstruct.create 0;
+      buffer = Bytes.empty;
       read_lock = Lwt_mutex.create ();
       write_lock = Lwt_mutex.create ();
     }
@@ -80,7 +82,7 @@ module Make (F : Formats.FRAMING) = struct
     Vchan_xen.client ~domid ~port () >|= fun vchan -> {
       vchan;
       domid;
-      buffer = Cstruct.create 0;
+      buffer = Bytes.empty;
       read_lock = Lwt_mutex.create ();
       write_lock = Lwt_mutex.create ();
     }

--- a/lib/msg_chan.ml
+++ b/lib/msg_chan.ml
@@ -54,7 +54,7 @@ module Make (F : Formats.FRAMING) = struct
     Lwt_mutex.with_lock t.read_lock @@ fun () ->
     if String.length t.buffer > 0 then (
       let data = t.buffer in
-      t.buffer <- String.empty;
+      t.buffer <- "";
       return (`Ok data)
     ) else (
       Vchan_xen.read t.vchan >|= unwrap_read >>!= fun result ->
@@ -75,7 +75,7 @@ module Make (F : Formats.FRAMING) = struct
     Vchan_xen.server ~domid ~port () >|= fun vchan -> {
       vchan;
       domid;
-      buffer = String.empty;
+      buffer = "";
       read_lock = Lwt_mutex.create ();
       write_lock = Lwt_mutex.create ();
     }
@@ -84,7 +84,7 @@ module Make (F : Formats.FRAMING) = struct
     Vchan_xen.client ~domid ~port () >|= fun vchan -> {
       vchan;
       domid;
-      buffer = String.empty;
+      buffer = "";
       read_lock = Lwt_mutex.create ();
       write_lock = Lwt_mutex.create ();
     }

--- a/lib/msg_chan.ml
+++ b/lib/msg_chan.ml
@@ -18,7 +18,7 @@ module Make (F : Formats.FRAMING) = struct
   type t = {
     domid : int;
     vchan : Vchan_xen.flow;
-    mutable buffer : String.t;
+    mutable buffer : string;
     read_lock : Lwt_mutex.t;
     write_lock : Lwt_mutex.t;
   }
@@ -50,7 +50,7 @@ module Make (F : Formats.FRAMING) = struct
       return (`Ok body)
     )
 
-  let recv_raw t : String.t S.or_eof Lwt.t =
+  let recv_raw t : string S.or_eof Lwt.t =
     Lwt_mutex.with_lock t.read_lock @@ fun () ->
     if String.length t.buffer > 0 then (
       let data = t.buffer in
@@ -62,7 +62,7 @@ module Make (F : Formats.FRAMING) = struct
       return (`Ok data)
     )
 
-  let send t (buffers : String.t list) : unit S.or_eof Lwt.t =
+  let send t (buffers : string list) : unit S.or_eof Lwt.t =
     let cs = List.map Cstruct.of_string buffers in
     Lwt_mutex.with_lock t.write_lock (fun () ->
       Vchan_xen.writev t.vchan cs >>= function

--- a/lib/msg_chan.ml
+++ b/lib/msg_chan.ml
@@ -27,7 +27,7 @@ module Make (F : Formats.FRAMING) = struct
     let avail = Bytes.length t.buffer in
     if avail >= size then (
       let retval = Bytes.sub t.buffer 0 size in
-      Bytes.blit t.buffer size t.buffer 0 (avail-size);
+      t.buffer <- Bytes.sub t.buffer size (avail-size);
       return (`Ok retval)
     ) else (
       Vchan_xen.read t.vchan >|= unwrap_read >>!= fun buf ->

--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -281,7 +281,6 @@ let port_of_int i =
   | Error (`Msg msg) -> failwith msg
 
 let parse_cmdline cmd =
-  let cmd = Bytes.to_string cmd in
   if cmd.[String.length cmd - 1] <> '\x00' then
     Lwt.fail_with "Command not null-terminated"
   else (
@@ -295,8 +294,9 @@ let exec t ~ty ~handler msg =
   Lwt.async (fun () ->
     let domid = get_exec_params_connect_domain msg |> Int32.to_int in
     let port = get_exec_params_connect_port msg |> port_of_int in
-    let cmdline = Bytes.sub msg sizeof_exec_params (Bytes.length msg) in
-    Log.debug (fun f -> f "Execute %S" (Bytes.to_string cmdline));
+    let len = Bytes.length msg in
+    let cmdline = Bytes.sub_string msg sizeof_exec_params (len - sizeof_exec_params) in
+    Log.debug (fun f -> f "Execute %S" cmdline);
     Lwt.finalize
       (fun () ->
         with_flow ~ty ~domid ~port (fun flow ->

--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -20,8 +20,8 @@ let split chr s =
 
 let or_fail = function
   | `Ok y -> Lwt.return y
-  | `Error (`Unknown msg) -> Lwt.fail_with msg
-  | `Eof -> Lwt.fail End_of_file
+  | `Error (`Unknown msg) -> failwith msg
+  | `Eof -> raise End_of_file
 
 let vchan_base_port =
   match Vchan.Port.of_string "512" with
@@ -257,7 +257,7 @@ let with_flow ~ty ~domid ~port fn =
           let version = negotiate_version peer_version in
           Flow.create ~version ~ty client
         )
-        (fun ex -> QV.disconnect client >>= fun () -> Lwt.fail ex)
+        (fun ex -> QV.disconnect client >>= fun () -> Lwt.reraise ex)
     )
     (fun flow ->
       Lwt.try_bind
@@ -281,7 +281,7 @@ let port_of_int i =
 
 let parse_cmdline cmd =
   if cmd.[String.length cmd - 1] <> '\x00' then
-    Lwt.fail_with "Command not null-terminated"
+    failwith "Command not null-terminated"
   else (
     let cmd = String.sub cmd 0 (String.length cmd - 1) in
     match cmd |> split ':' with

--- a/lib/rExec.ml
+++ b/lib/rExec.ml
@@ -64,7 +64,7 @@ let recv t =
 module Flow = struct
   type t = {
     dstream : QV.t;
-    mutable stdin_buf : String.t;
+    mutable stdin_buf : string;
     ty : [`Just_exec | `Exec_cmdline];
     version : Formats.Qrexec.version;
   }
@@ -139,8 +139,8 @@ end
 module Client_flow = struct
   type t = {
     dstream : QV.t;
-    mutable stdout_buf : String.t;
-    mutable stderr_buf : String.t;
+    mutable stdout_buf : string;
+    mutable stderr_buf : string;
     version : Formats.Qrexec.version;
   }
 

--- a/lib/rExec.mli
+++ b/lib/rExec.mli
@@ -11,12 +11,12 @@ module Flow : S.FLOW
 module Client_flow : sig
   type t
 
-  val write : t -> String.t -> [`Ok of unit | `Eof] Lwt.t
+  val write : t -> string -> [`Ok of unit | `Eof] Lwt.t
   (** Write to stdin *)
   val writef : t -> ('a, unit, string, [`Ok of unit | `Eof] Lwt.t) format4 -> 'a
   (* Write a formatted string to stdin *)
 
-  val read : t -> [`Stdout of String.t | `Stderr of String.t
+  val read : t -> [`Stdout of string | `Stderr of string
                   | `Eof | `Exit_code of int32] Lwt.t
   (** Read from stdout and stderr *)
 end

--- a/lib/rExec.mli
+++ b/lib/rExec.mli
@@ -11,13 +11,13 @@ module Flow : S.FLOW
 module Client_flow : sig
   type t
 
-  val write : t -> Cstruct.t -> [`Ok of unit | `Eof] Lwt.t
+  val write : t -> Bytes.t -> [`Ok of unit | `Eof] Lwt.t
   (** Write to stdin *)
   val writef : t -> ('a, unit, string, [`Ok of unit | `Eof] Lwt.t) format4 -> 'a
   (* Write a formatted string to stdin *)
 
-  val read : t -> [`Stdout of Cstruct.t | `Stderr of Cstruct.t
-                  | `Eof | `Exit_code of Cstruct.uint32] Lwt.t
+  val read : t -> [`Stdout of Bytes.t | `Stderr of Bytes.t
+                  | `Eof | `Exit_code of int32] Lwt.t
   (** Read from stdout and stderr *)
 end
 

--- a/lib/rExec.mli
+++ b/lib/rExec.mli
@@ -11,12 +11,12 @@ module Flow : S.FLOW
 module Client_flow : sig
   type t
 
-  val write : t -> Bytes.t -> [`Ok of unit | `Eof] Lwt.t
+  val write : t -> String.t -> [`Ok of unit | `Eof] Lwt.t
   (** Write to stdin *)
   val writef : t -> ('a, unit, string, [`Ok of unit | `Eof] Lwt.t) format4 -> 'a
   (* Write a formatted string to stdin *)
 
-  val read : t -> [`Stdout of Bytes.t | `Stderr of Bytes.t
+  val read : t -> [`Stdout of String.t | `Stderr of String.t
                   | `Eof | `Exit_code of int32] Lwt.t
   (** Read from stdout and stderr *)
 end

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -5,36 +5,36 @@ type 'a or_eof =
 module type MSG_CHAN = sig
   type t
 
-  val recv : t -> (Bytes.t * Bytes.t) or_eof Lwt.t
+  val recv : t -> (String.t * String.t) or_eof Lwt.t
   (** Receive one packet (header and body) *)
 
-  val recv_fixed : t -> int -> Bytes.t or_eof Lwt.t
+  val recv_fixed : t -> int -> String.t or_eof Lwt.t
   (** Receive one packet of known size (no header) *)
 
-  val recv_raw : t -> Bytes.t or_eof Lwt.t
+  val recv_raw : t -> String.t or_eof Lwt.t
   (** Read a chunk of data from the stream.
       Blocks if no data is available yet. *)
 
-  val send : t -> Bytes.t list -> unit or_eof Lwt.t
+  val send : t -> String.t list -> unit or_eof Lwt.t
   (** Send one or more packets (takes the mutex) *)
 end
 
 module type FLOW = sig
   type t
 
-  val write : t -> Bytes.t -> unit Lwt.t
+  val write : t -> String.t -> unit Lwt.t
   (** Write to stdout *)
 
   val writef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
   (** Write a formatted line to stdout. *)
 
-  val ewrite : t -> Bytes.t -> unit Lwt.t
+  val ewrite : t -> String.t -> unit Lwt.t
   (** Write to stderr *)
 
   val ewritef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
   (** Write a formatted line to stderr. *)
 
-  val read : t -> [`Ok of Bytes.t | `Eof] Lwt.t
+  val read : t -> [`Ok of String.t | `Eof] Lwt.t
   (** Read from stdin. *)
 
   val read_line : t -> [`Ok of string | `Eof] Lwt.t

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -5,36 +5,36 @@ type 'a or_eof =
 module type MSG_CHAN = sig
   type t
 
-  val recv : t -> (String.t * String.t) or_eof Lwt.t
+  val recv : t -> (string * string) or_eof Lwt.t
   (** Receive one packet (header and body) *)
 
-  val recv_fixed : t -> int -> String.t or_eof Lwt.t
+  val recv_fixed : t -> int -> string or_eof Lwt.t
   (** Receive one packet of known size (no header) *)
 
-  val recv_raw : t -> String.t or_eof Lwt.t
+  val recv_raw : t -> string or_eof Lwt.t
   (** Read a chunk of data from the stream.
       Blocks if no data is available yet. *)
 
-  val send : t -> String.t list -> unit or_eof Lwt.t
+  val send : t -> string list -> unit or_eof Lwt.t
   (** Send one or more packets (takes the mutex) *)
 end
 
 module type FLOW = sig
   type t
 
-  val write : t -> String.t -> unit Lwt.t
+  val write : t -> string -> unit Lwt.t
   (** Write to stdout *)
 
   val writef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
   (** Write a formatted line to stdout. *)
 
-  val ewrite : t -> String.t -> unit Lwt.t
+  val ewrite : t -> string -> unit Lwt.t
   (** Write to stderr *)
 
   val ewritef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
   (** Write a formatted line to stderr. *)
 
-  val read : t -> [`Ok of String.t | `Eof] Lwt.t
+  val read : t -> [`Ok of string | `Eof] Lwt.t
   (** Read from stdin. *)
 
   val read_line : t -> [`Ok of string | `Eof] Lwt.t

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -5,36 +5,36 @@ type 'a or_eof =
 module type MSG_CHAN = sig
   type t
 
-  val recv : t -> (Cstruct.t * Cstruct.t) or_eof Lwt.t
+  val recv : t -> (Bytes.t * Bytes.t) or_eof Lwt.t
   (** Receive one packet (header and body) *)
 
-  val recv_fixed : t -> int -> Cstruct.t or_eof Lwt.t
+  val recv_fixed : t -> int -> Bytes.t or_eof Lwt.t
   (** Receive one packet of known size (no header) *)
 
-  val recv_raw : t -> Cstruct.t or_eof Lwt.t
+  val recv_raw : t -> Bytes.t or_eof Lwt.t
   (** Read a chunk of data from the stream.
       Blocks if no data is available yet. *)
 
-  val send : t -> Cstruct.t list -> unit or_eof Lwt.t
+  val send : t -> Bytes.t list -> unit or_eof Lwt.t
   (** Send one or more packets (takes the mutex) *)
 end
 
 module type FLOW = sig
   type t
 
-  val write : t -> Cstruct.t -> unit Lwt.t
+  val write : t -> Bytes.t -> unit Lwt.t
   (** Write to stdout *)
 
   val writef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
   (** Write a formatted line to stdout. *)
 
-  val ewrite : t -> Cstruct.t -> unit Lwt.t
+  val ewrite : t -> Bytes.t -> unit Lwt.t
   (** Write to stderr *)
 
   val ewritef : t -> ('a, unit, string, unit Lwt.t) format4 -> 'a
   (** Write a formatted line to stderr. *)
 
-  val read : t -> [`Ok of Cstruct.t | `Eof] Lwt.t
+  val read : t -> [`Ok of Bytes.t | `Eof] Lwt.t
   (** Read from stdin. *)
 
   val read_line : t -> [`Ok of string | `Eof] Lwt.t

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -21,7 +21,6 @@ depends: [
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "cstruct" { >= "6.0.0" }
   "lwt"
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.06.0" }

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -22,7 +22,6 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "lwt"
-  "logs" { >= "0.5.0" }
   "ocaml" { >= "4.06.0" }
 ]
 synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -20,6 +20,7 @@ depends: [
   "lwt"
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.08.0" }
+  "ohex"
   "fmt" {>= "0.8.5"}
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -20,7 +20,7 @@ depends: [
   "lwt"
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.08.0" }
-  "ohex"
+  "ohex" { >= "0.2.0" }
   "fmt" {>= "0.8.5"}
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -15,7 +15,6 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "cstruct" { >= "6.0.0" }
-  "ppx_cstruct"
   "vchan-xen" { >= "6.0.0" }
   "mirage-xen" { >= "6.0.0" }
   "lwt"


### PR DESCRIPTION
Dear devs,
This PR wants to remove most of the `Cstruct.t` uses (the remaining is kept for ocaml-vchan and probably it can be difficult to change the API as it uses io-pages with Xen, but there is some ppx_cstruct that couldn't be changed anyway). 
So as this was one of the first _un-ppx_cstruct-ion_ for me, there is probably a lot of improvement to be done (~~I have a lot of `Bytes.t` / `String` conversion, and `Bytes.blit` that might be unwanted copies...) + I still have some missing `Cstruct.hexdump`-like that would be great to print out (those are limited to `gUI.ml` but qubes-mirage-firewall, that I use for testing the PR, doesn't use `gUI.ml` at all~~).
Any review / comments are welcome :)
Best,