### PR TITLE
Upgrade the package with tcpip.8.1.0

### DIFF
--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -703,7 +703,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
   (* type mfn : uint32_t;  big-endian 24-bit RGB pixel *)
 
   let make_with_header ~window ~ty ~body_len body =
-    (** see qubes-gui-agent-linux/include/txrx.h:#define write_message *)
+    (* see qubes-gui-agent-linux/include/txrx.h:#define write_message *)
     String.concat "" [
       of_int32_le (msg_type_to_int ty) ;
       of_int32_le window ;

--- a/lib/ipv4/qubesdb_ipv4.mli
+++ b/lib/ipv4/qubesdb_ipv4.mli
@@ -6,6 +6,7 @@ module Make
     (Arp : Arp.S) : sig
 
   include Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t
+                      and type prefix = Ipaddr.V4.Prefix.t
   val connect : D.t -> Ethernet.t -> Arp.t -> t Lwt.t
   (** [connect db ethernet arp] attempts to use the provided [db]
    *  to look up the correct IPV4 information, and construct

--- a/lib/rExec.mli
+++ b/lib/rExec.mli
@@ -13,6 +13,7 @@ module Client_flow : sig
 
   val write : t -> string -> [`Ok of unit | `Eof] Lwt.t
   (** Write to stdin *)
+
   val writef : t -> ('a, unit, string, [`Ok of unit | `Eof] Lwt.t) format4 -> 'a
   (* Write a formatted string to stdin *)
 

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "7.0.0" }
+  "tcpip" { >= "8.1.0" }
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "ipaddr" { >= "3.0.0" }


### PR DESCRIPTION
Gently upgrade to the last change on `mirage-tcpip.8.1.0`, the prefix must be defined now. (/cc @hannesm, /cc @palainp)