### PR TITLE
Add common code for Qubes unikernels

### DIFF
--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -1,15 +1,15 @@
 
-let check_memory () =
+let check_memory ?(fraction=0.4) () =
   let fraction_free stats =
     let { Xen_os.Memory.free_words; heap_words; _ } = stats in
     float free_words /. float heap_words
   in
   let stats = Xen_os.Memory.stat () in
-  if fraction_free stats > 0.4 then `Ok
+  if fraction_free stats > fraction then `Ok
   else (
     Gc.full_major ();
     let stats = Xen_os.Memory.quick_stat () in
-    if fraction_free stats < 0.4 then `Memory_critical
+    if fraction_free stats < fraction then `Memory_critical
     else `Ok
   )
 

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -1,5 +1,6 @@
 
 let check_memory ?(fraction=40) () =
+  if fraction <= 0 || fraction >= 100 then invalid_arg "fraction invalid: 0 < fraction < 100";
   let is_enough stats =
     let { Xen_os.Memory.free_words; heap_words; _ } = stats in
     (* Assuming 64bits integers, the following should not overlap *)

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -1,0 +1,19 @@
+
+let check_memory () =
+  let fraction_free stats =
+    let { Xen_os.Memory.free_words; heap_words; _ } = stats in
+    float free_words /. float heap_words
+  in
+  let stats = Xen_os.Memory.stat () in
+  if fraction_free stats > 0.4 then `Ok
+  else (
+    Gc.full_major ();
+    let stats = Xen_os.Memory.quick_stat () in
+    if fraction_free stats < 0.4 then `Memory_critical
+    else `Ok
+  )
+
+let shutdown =
+  let ( let* ) = Lwt.bind in
+  let* value = Xen_os.Lifecycle.await_shutdown_request () in
+  match value with `Poweroff | `Reboot -> Lwt.return_unit

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -1,16 +1,17 @@
 
-let check_memory ?(fraction=0.4) () =
-  let fraction_free stats =
+let check_memory ?(fraction=40) () =
+  let is_enough stats =
     let { Xen_os.Memory.free_words; heap_words; _ } = stats in
-    float free_words /. float heap_words
+    (* Assuming 64bits integers, the following should not overlap *)
+    free_words * 100 >  heap_words * fraction
   in
   let stats = Xen_os.Memory.stat () in
-  if fraction_free stats > fraction then `Ok
+  if is_enough stats then `Ok
   else (
     Gc.full_major ();
     let stats = Xen_os.Memory.quick_stat () in
-    if fraction_free stats < fraction then `Memory_critical
-    else `Ok
+    if is_enough stats then `Ok
+    else `Memory_critical
   )
 
 let shutdown =

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -1,0 +1,9 @@
+val check_memory : unit -> [ `Ok | `Memory_critical ]
+(** Check the memory situation, it triggers a garbage collection if
+    free memory is low (below 40%, work-around for
+    http://caml.inria.fr/mantis/view.php?id=7100 and OCaml GC needing
+    to malloc extra space to run finalisers), and returns either `Ok
+    or `Memory_critical if free memory is above or below 40%. *)
+
+val shutdown : unit Lwt.t
+(** Waits for `Poweroff or `Reboot from dom0. *)

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -1,9 +1,9 @@
-val check_memory : ?fraction:float -> unit -> [ `Ok | `Memory_critical ]
+val check_memory : ?fraction:int -> unit -> [ `Ok | `Memory_critical ]
 (** Check the memory situation, it triggers a garbage collection if
-    free memory is low (below [fraction], work-around for
+    free memory is low (below [fraction]%, work-around for
     http://caml.inria.fr/mantis/view.php?id=7100 and OCaml GC needing
     to malloc extra space to run finalisers), and returns either `Ok
-    or `Memory_critical if free memory is above or below [fraction]. *)
+    or `Memory_critical if free memory is above or below [fraction]%. *)
 
 val shutdown : unit Lwt.t
 (** Waits for `Poweroff or `Reboot from dom0. *)

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -1,9 +1,9 @@
-val check_memory : unit -> [ `Ok | `Memory_critical ]
+val check_memory : ?fraction:float -> unit -> [ `Ok | `Memory_critical ]
 (** Check the memory situation, it triggers a garbage collection if
-    free memory is low (below 40%, work-around for
+    free memory is low (below [fraction], work-around for
     http://caml.inria.fr/mantis/view.php?id=7100 and OCaml GC needing
     to malloc extra space to run finalisers), and returns either `Ok
-    or `Memory_critical if free memory is above or below 40%. *)
+    or `Memory_critical if free memory is above or below [fraction]. *)
 
 val shutdown : unit Lwt.t
 (** Waits for `Poweroff or `Reboot from dom0. *)


### PR DESCRIPTION
This PR is a starting point for #70 . I was unsure how to add functions that can be called directly like `Mirage_qubes.shutdown`  so I stuck with `Mirage_qubes.Misc.shutdown`.

I also left `Mirage_qubes.Misc.check_memory ()` as it works fine with qubes-mirage-firewall (and some quick tests with qubes-miragevpn). Perhaps it would be better to add the free memory ratio as parameters if the different unikernels need a different tuning ratio? I dislike hard coded values :(, but as @hannesm said, this should be less critical with the cstruct deleting process underway :)

If merged, it should be easy to update the various Qubes unikernels :)