### PR TITLE
revise to dune variants used, and fewer functors

### DIFF
--- a/lib/ipv4/dune
+++ b/lib/ipv4/dune
@@ -1,5 +1,4 @@
 (library
  (name qubesdb_ipv4)
  (public_name mirage-qubes-ipv4)
- (libraries lwt tcpip tcpip.ipv4 ipaddr
-   arp ethernet mirage-qubes mirage-clock mirage-crypto-rng-mirage))
+ (libraries lwt tcpip tcpip.ipv4 ipaddr arp ethernet mirage-qubes))

--- a/lib/ipv4/qubesdb_ipv4.ml
+++ b/lib/ipv4/qubesdb_ipv4.ml
@@ -1,10 +1,8 @@
 module Make
     (D: Qubes.S.DB)
-    (R: Mirage_crypto_rng_mirage.S)
-    (C: Mirage_clock.MCLOCK)
     (Ethernet : Ethernet.S)
     (Arp : Arp.S) = struct
-  include Static_ipv4.Make(R)(C)(Ethernet)(Arp)
+  include Static_ipv4.Make(Ethernet)(Arp)
   let connect db ethif arp =
     let (>>=?) ip f = match ip with
       | None -> Error (`Msg "couldn't read qubesdb")

--- a/lib/ipv4/qubesdb_ipv4.mli
+++ b/lib/ipv4/qubesdb_ipv4.mli
@@ -1,7 +1,5 @@
 module Make
     (D : Qubes.S.DB)
-    (R : Mirage_crypto_rng_mirage.S)
-    (C : Mirage_clock.MCLOCK)
     (Ethernet : Ethernet.S)
     (Arp : Arp.S) : sig
 

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -15,12 +15,10 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "8.2.0" }
+  "tcpip" { >= "9.0.0" }
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "ipaddr" { >= "3.0.0" }
-  "mirage-crypto-rng-mirage" {>= "1.0.0"}
-  "mirage-clock" {>= "3.0.0"}
   "lwt" { >= "5.7.0" }
   "ocaml" { >= "4.06.0" }
 ]


### PR DESCRIPTION
requires tcpip being released https://github.com/ocaml/opam-repository/pull/27400